### PR TITLE
Expose the ability to compile brushlib as a shared object/dynamic library

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -66,9 +66,6 @@ if env['enable_introspection']:
     env['use_sharedlib'] = True
     print "Enabling glib because of enable_introspection=true"
     print "Building a shared lib instead of a static lib because of enable_introspection=true"
-else:
-    env['use_sharedlib'] = False
-    env['use_glib'] = False
 
 Export('env')
 

--- a/SConstruct
+++ b/SConstruct
@@ -24,6 +24,8 @@ opts.Add(BoolVariable('enable_introspection', 'enable GObject introspection supp
 opts.Add(BoolVariable('enable_docs', 'enable documentation build', False))
 opts.Add(BoolVariable('enable_gperftools', 'enable gperftools in build, for profiling', False))
 opts.Add(BoolVariable('enable_openmp', 'enable OpenMP for multithreaded processing (on by default)', True))
+opts.Add(BoolVariable('use_sharedlib', 'build a shared library instead of a static library (forced on by introspection)', False))
+opts.Add(BoolVariable('use_glib', 'enable glib (forced on by introspection)', False))
 opts.Add('python_binary', 'python executable to build for', default_python_binary)
 
 tools = ['default', 'textfile']


### PR DESCRIPTION
For some reason this was hidden away, and forced to false if introspection wasn't enabled.
