### PR TITLE
Don't link to gettext's private libgettextlib

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -93,7 +93,7 @@ if env['enable_openmp']:
 if env['enable_i18n']:
     env.Append(CPPDEFINES='HAVE_GETTEXT')
     if sys.platform == "darwin":
-        libs += ['intl', 'gettextlib']
+        libs += ['intl']
 
 
 config_defines = ''


### PR DESCRIPTION
It's not needed, and functions from the portion of glib included within may not be compatible with the functions provided by the system's full version of glib, which may result in a crash like mypaint/mypaint#114
