### PR TITLE
Remove deprecated pylab usage.

### DIFF
--- a/doc/scripts/dab_hardness_plot.py
+++ b/doc/scripts/dab_hardness_plot.py
@@ -1,38 +1,39 @@
-from pylab import *
+import numpy as np
+import matplotlib.pyplot as plt
 
-dab = imread('parametric_dab.png')
+dab = plt.imread('parametric_dab.png')
 
 print dab.shape
 
 l = dab[500, :, 3]
-#plot(l, label="opacity")
+#plt.plot(l, label="opacity")
 
-r = hstack((linspace(1, 0, 500), linspace(0, 1, 500)[1:]))
-#plot(r, label="$r$")
+r = np.hstack((np.linspace(1, 0, 500), np.linspace(0, 1, 500)[1:]))
+#plt.plot(r, label="$r$")
 
 rr = r**2
 o = 1.0-rr
-#plot(o, label="$1-r^2$")
+#plt.plot(o, label="$1-r^2$")
 
 for i in [1, 2]:
-    figure(i)
+    plt.figure(i)
     hardness = 0.3
     for hardness in [0.1, 0.3, 0.7]:
         if i == 2:
-            rr = linspace(0, 1, 1000)
+            rr = np.linspace(0, 1, 1000)
         opa = rr.copy()
         opa[rr < hardness] = rr[rr < hardness] + 1-(rr[rr < hardness]/hardness)
         opa[rr >= hardness] = hardness/(1-hardness)*(1-rr[rr >= hardness])
-        plot(opa, label="h=%.1f" % hardness)
+        plt.plot(opa, label="h=%.1f" % hardness)
         if i == 2:
-            xlabel("$r^2$")
-            legend(loc='best')
+            plt.xlabel("$r^2$")
+            plt.legend(loc='best')
         else:
-            xlabel("$d$")
-            legend(loc='lower center')
+            plt.xlabel("$d$")
+            plt.legend(loc='lower center')
 
-    ylabel('pixel opacity')
-    xticks([500], [0])
-    title("Dab Shape (for different hardness values)")
+    plt.ylabel('pixel opacity')
+    plt.xticks([500], [0])
+    plt.title("Dab Shape (for different hardness values)")
 
-show()
+plt.show()


### PR DESCRIPTION
`pylab` has been deprecated by matplotlib since forever now. The `parametric_dab.png` referenced herein doesn't seem to exist, but the code still seemed to work with whatever I threw at it (a copy of `doc/images/rendered_dab_whitbg.png` with added alpha channel).