### PR TITLE
Py3k stage 1

### DIFF
--- a/doc/scripts/dab_hardness_plot.py
+++ b/doc/scripts/dab_hardness_plot.py
@@ -1,5 +1,8 @@
+from __future__ import absolute_import
+
 import numpy as np
 import matplotlib.pyplot as plt
+
 
 dab = plt.imread('parametric_dab.png')
 

--- a/doc/scripts/dab_hardness_plot.py
+++ b/doc/scripts/dab_hardness_plot.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 
 dab = plt.imread('parametric_dab.png')
 
-print dab.shape
+print(dab.shape)
 
 l = dab[500, :, 3]
 #plt.plot(l, label="opacity")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,6 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import absolute_import
+
 import os
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import os
 
@@ -32,7 +32,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphin
 # Breathe setup, for integrating doxygen content
 extensions.append('breathe')
 doxyxml_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../doxygen')
-print doxyxml_dir
+print(doxyxml_dir)
 breathe_projects = {"libmypaint": doxyxml_dir}
 breathe_default_project = "libmypaint"
 

--- a/examples/gegl.py
+++ b/examples/gegl.py
@@ -1,5 +1,5 @@
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 from gi.repository import GeglGtk3 as GeglGtk
 from gi.repository import Gegl, Gtk
@@ -95,22 +95,25 @@ def list_settings():
     # List all settings
     # TODO: Is there a better way to list all enums with GI?
     settings = [str(getattr(MyPaint.BrushSetting, attr)) for attr in dir(MyPaint.BrushSetting) if attr.startswith("SETTING_")]
-    print "Available settings: %s\n" % "\n".join(settings)
+    print("Available settings: %s\n" % "\n".join(settings))
 
     # Get info about a given setting
     setting = MyPaint.BrushSetting.SETTING_RADIUS_LOGARITHMIC
     info = MyPaint.brush_setting_info(setting)
 
     # TODO: rename "def_" to "default"
-    print "Setting: %s\n\t Max: %f \n\t Default: %f \n\t Min: %f" % (info.cname, info.max, info.def_, info.min)
-    print "\t Name: %s\n\t Tooltip: '%s'\n" % (info.get_name(), info.get_tooltip())  # Use the getters so that i18n works
+    print("Setting: %s\n\t Max: %f \n\t Default: %f \n\t Min: %f" % (
+        info.cname, info.max, info.def_, info.min))
+    # Use the getters so that i18n works
+    print("\t Name: %s\n\t Tooltip: '%s'\n" % (info.get_name(),
+                                               info.get_tooltip()))
 
     # TODO: should be MyPaint.BrushSetting.from_cname
     # Same with MyPaint.Brush.input_from_cname
     assert (MyPaint.Brush.setting_from_cname(info.cname) == setting)
 
     # Get/Set current base value for the given setting
-    print "Base value is: %f" % brush.get_base_value(setting)
+    print("Base value is: %f" % brush.get_base_value(setting))
     brush.set_base_value(setting, 2.0)
     assert brush.get_base_value(setting) == 2.0
 
@@ -121,7 +124,7 @@ def list_settings():
             mapping_points = brush.get_mapping_n(setting, input)
             if mapping_points > 1:  # If 0, no dynamics for this input
                 points = [brush.get_mapping_point(setting, input, i) for i in range(mapping_points)]
-                print "Has dynamics for input %s:\n%s" % (input, str(points))
+                print("Has dynamics for input %s:\n%s" % (input, str(points)))
 
 
 if __name__ == '__main__':

--- a/examples/gegl.py
+++ b/examples/gegl.py
@@ -1,4 +1,6 @@
 
+from __future__ import absolute_import
+
 from gi.repository import GeglGtk3 as GeglGtk
 from gi.repository import Gegl, Gtk
 from gi.repository import MyPaint, MyPaintGegl

--- a/generate.py
+++ b/generate.py
@@ -18,6 +18,8 @@
 
 "Code generator, part of the build process."
 
+from __future__ import absolute_import
+
 import os
 import sys
 from os.path import basename

--- a/generate.py
+++ b/generate.py
@@ -18,7 +18,7 @@
 
 "Code generator, part of the build process."
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import os
 import sys
@@ -229,7 +229,7 @@ if __name__ == '__main__':
         public_header_file, internal_header_file = sys.argv[1:]
     except:
         msg = "usage: {} PUBLICdotH INTERNALdotH".format(script)
-        print >>sys.stderr, msg
+        print(msg, file=sys.stderr)
         sys.exit(2)
     writefile(public_header_file, generate_public_settings_code())
     writefile(internal_header_file, generate_internal_settings_code())

--- a/tests/ctests.py
+++ b/tests/ctests.py
@@ -1,4 +1,6 @@
 
+from __future__ import absolute_import
+
 import os
 
 # TODO: get more fine grained test setup

--- a/tests/ctests.py
+++ b/tests/ctests.py
@@ -1,5 +1,5 @@
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import os
 

--- a/tests/test_ctests.py
+++ b/tests/test_ctests.py
@@ -1,4 +1,6 @@
 
+from __future__ import absolute_import
+
 import os
 import ctests
 

--- a/tests/test_ctests.py
+++ b/tests/test_ctests.py
@@ -1,5 +1,5 @@
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import os
 import ctests


### PR DESCRIPTION
The results of `futurize --stage1`. These are changes that are cross-compatible between 2 and 3. The changes are minimal due to this and mostly consist of importing things from `__future__`.

This is based on #20 since there are some minor conflicts.