### PR TITLE
Standardize libmypaint build for both GIMP and MyPaint

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -79,11 +79,12 @@ top_env = env
 env = env.Clone()
 
 if env['enable_introspection']:
-    env['use_glib'] = True
-    env['use_sharedlib'] = True
-    print "Enabling glib because of enable_introspection=true"
+    if not env['use_glib']:
+        print "Enabling glib because of enable_introspection=true"
     if not env['use_sharedlib']:
         print "Building a shared lib instead of a static lib because of enable_introspection=true"
+    env['use_glib'] = True
+    env['use_sharedlib'] = True
 
 Export('env')
 

--- a/SConscript
+++ b/SConscript
@@ -82,7 +82,8 @@ if env['enable_introspection']:
     env['use_glib'] = True
     env['use_sharedlib'] = True
     print "Enabling glib because of enable_introspection=true"
-    print "Building a shared lib instead of a static lib because of enable_introspection=true"
+    if not env['use_sharedlib']:
+        print "Building a shared lib instead of a static lib because of enable_introspection=true"
 
 Export('env')
 

--- a/SConstruct
+++ b/SConstruct
@@ -32,7 +32,7 @@ opts.Add(BoolVariable('enable_introspection', 'enable GObject introspection supp
 opts.Add(BoolVariable('enable_docs', 'enable documentation build', False))
 opts.Add(BoolVariable('enable_gperftools', 'enable gperftools in build, for profiling', False))
 opts.Add(BoolVariable('enable_openmp', 'enable OpenMP for multithreaded processing', default_openmp))
-opts.Add(BoolVariable('use_sharedlib', 'build a shared library instead of a static library (forced on by introspection)', False))
+opts.Add(BoolVariable('use_sharedlib', 'build a shared library instead of a static library (forced on by introspection)', True))
 opts.Add(BoolVariable('use_glib', 'enable glib (forced on by introspection)', False))
 opts.Add('python_binary', 'python executable to build for', default_python_binary)
 

--- a/mypaint-config.h
+++ b/mypaint-config.h
@@ -14,7 +14,7 @@
 #endif
 
 // Start generated config
-#define MYPAINT_CONFIG_USE_GLIB 0
+#define MYPAINT_CONFIG_USE_GLIB 1
 
 // End generated config
 


### PR DESCRIPTION
This implements requests from issue #28.

- enable_gegl=true and use_sharedlibs=true are now the default.
- MyPaint-only environments can still disable gegl by building with enable_gegl=false.
- GIMP does not need introspection as of today. If it happens someday, we can still discuss to change the default value of enable_introspection later. :-)
Of course, if you prefer, we can also make it a default value to true. I don't think it is any problem for us.