### PR TITLE
Allow specification of sphinx-build binary

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -35,6 +35,7 @@ opts.Add(BoolVariable('enable_openmp', 'enable OpenMP for multithreaded processi
 opts.Add(BoolVariable('use_sharedlib', 'build a shared library instead of a static library (forced on by introspection)', True))
 opts.Add(BoolVariable('use_glib', 'enable glib (forced on by introspection)', False))
 opts.Add('python_binary', 'python executable to build for', default_python_binary)
+opts.Add('sphinx_build_binary', 'sphinx-build binary used for building documentation', 'sphinx-build')
 
 tools = ['default', 'textfile']
 

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -3,5 +3,5 @@ Import('env')
 env = env.Clone()
 
 env.Command('doxygen/index.xml', 'Doxyfile', 'cd $TARGET.dir && doxygen ../$SOURCE.file')
-sphinx_build = env.Command('build/index.html', 'source/index.rst', 'sphinx-build2 $SOURCE.dir $TARGET.dir')
+sphinx_build = env.Command('build/index.html', 'source/index.rst', env['sphinx_build_binary'] + ' $SOURCE.dir $TARGET.dir')
 Depends(sphinx_build, 'doxygen/index.xml')


### PR DESCRIPTION
The name of the `sphinx-build` binary can be different, depending on the Python version used and how it is packaged in the operating system (`sphinx-build`, `sphinx-build2`, `sphinx-build-3.4`, ...). This patch adds specifying `sphinx_build_binary` so the scripts use the correct one.