### PR TITLE
Fix the build on FreeBSD

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -108,7 +108,7 @@ if env['enable_openmp']:
 
 if env['enable_i18n']:
     env.Append(CPPDEFINES='HAVE_GETTEXT')
-    if sys.platform == "darwin":
+    if not sys.platform.startswith("gnu") and not sys.platform.startswith("linux"):
         libs += ['intl']
 
 

--- a/gegl/mypaint-gegl-surface.c
+++ b/gegl/mypaint-gegl-surface.c
@@ -20,13 +20,13 @@
 #include "mypaint-gegl-surface.h"
 #include <gegl-utils.h>
 
-typedef struct _MyPaintGeglTiledSurface {
+struct _MyPaintGeglTiledSurface {
     MyPaintTiledSurface parent;
 
     GeglRectangle extent_rect; // TODO: remove, just use the extent of the buffer
     GeglBuffer *buffer;
     const Babl *format;
-} MyPaintGeglTiledSurface;
+};
 
 #include <glib/mypaint-gegl-glib.c>
 

--- a/mypaint-tiled-surface.c
+++ b/mypaint-tiled-surface.c
@@ -645,7 +645,9 @@ void get_color (MyPaintSurface *surface, float x, float y,
     int tx2 = floor(floor(x + r_fringe) / MYPAINT_TILE_SIZE);
     int ty1 = floor(floor(y - r_fringe) / MYPAINT_TILE_SIZE);
     int ty2 = floor(floor(y + r_fringe) / MYPAINT_TILE_SIZE);
+    #ifdef _OPENMP
     int tiles_n = (tx2 - tx1) * (ty2 - ty1);
+    #endif
 
     #pragma omp parallel for schedule(static) if(self->threadsafe_tile_requests && tiles_n > 3)
     for (int ty = ty1; ty <= ty2; ty++) {


### PR DESCRIPTION
There are 3 patches that fix libmypaint build on FreeBSD 10 with clang 3.4. It currently only works when GLib is enabled. Type redefinition problem (https://github.com/mypaint/libmypaint/issues/33#issuecomment-167847420) will show if GLib is disabled because we don't use C11.