### PR TITLE
Allow specifying libdir, includedir, datadir

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -52,7 +52,7 @@ def create_pkgconfig_files(env, pkgconfig_name, version, description,
     }
     pc_file = env.Substfile('%s.pc' % pkgconfig_name,
                             "pkgconfig.pc.in", SUBST_DICT=pkg_info)
-    install_perms(env, '$prefix/lib/pkgconfig', pc_file)
+    install_perms(env, '$libdir/pkgconfig', pc_file)
 
     return pc_file
 
@@ -162,14 +162,14 @@ if env['enable_introspection']:
                               Glob("glib/mypaint-[!gegl]*.c") + Glob("glib/mypaint-[!gegl]*.h"),
                               ['./'], brushlib, ['glib-2.0'], [])
 
-    install_perms(env, '$prefix/share/gir-1.0', gir)
-    install_perms(env, '$prefix/lib/girepository-1.0', typelib)
+    install_perms(env, '$datadir/gir-1.0', gir)
+    install_perms(env, '$libdir/girepository-1.0', typelib)
 
-install_perms(env, '$prefix/lib/', brushlib)
-install_perms(env, '$prefix/include/libmypaint', Glob("./mypaint-*.h"))
-install_perms(env, '$prefix/include/libmypaint/glib', Glob("./glib/mypaint-*.h"))
-install_perms(env, "$prefix/share/libmypaint", Glob("./*.py"))
-install_perms(env, "$prefix/share/libmypaint", "./brushsettings.json")
+install_perms(env, '$libdir/', brushlib)
+install_perms(env, '$includedir/libmypaint', Glob("./mypaint-*.h"))
+install_perms(env, '$includedir/libmypaint/glib', Glob("./glib/mypaint-*.h"))
+install_perms(env, "$datadir/libmypaint", Glob("./*.py"))
+install_perms(env, "$datadir/libmypaint", "./brushsettings.json")
 
 if env['enable_i18n']:
     languages = SConscript('po/SConscript')
@@ -185,8 +185,8 @@ if env['enable_gegl']:
     lib_builder = gegl_env.SharedLibrary if env['use_sharedlib'] else gegl_env.StaticPicLibrary
     brushlib_gegl = lib_builder('./mypaint-gegl', Glob("./gegl/*.c"))
 
-    install_perms(env, '$prefix/lib/', brushlib_gegl)
-    install_perms(env, '$prefix/include/libmypaint-gegl', Glob("./gegl/mypaint-gegl-*.h"))
+    install_perms(env, '$libdir/', brushlib_gegl)
+    install_perms(env, '$includedir/libmypaint-gegl', Glob("./gegl/mypaint-gegl-*.h"))
 
     create_pkgconfig_files(env, 'libmypaint-gegl', brushlib_version, 'MyPaint brush engine library, with GEGL integration',
                            libname='mypaint-gegl', deps=deps + ['libmypaint'])
@@ -200,8 +200,8 @@ if env['enable_gegl']:
                                   ['glib-2.0', 'gegl-%s' % env['GEGL_VERSION']],
                                   ['Gegl-%s' % env['GEGL_VERSION'], 'MyPaint-%s' % brushlib_version])
 
-        install_perms(env, '$prefix/share/gir-1.0', gir)
-        install_perms(env, '$prefix/lib/girepository-1.0', typelib)
+        install_perms(env, '$datadir/gir-1.0', gir)
+        install_perms(env, '$libdir/girepository-1.0', typelib)
 
 Export('gegl_env', 'env', 'parse_pkg_config')
 tests = SConscript('tests/SConscript')

--- a/SConstruct
+++ b/SConstruct
@@ -24,6 +24,9 @@ opts.Add(
     default=default_prefix,
     validator=isabs,
 )
+opts.Add('libdir', 'Directory into which libraries are installed', default='lib')
+opts.Add('includedir', 'Directory into which headers are installed', default='include')
+opts.Add('datadir', 'Directory into which shared data is installed', default='share')
 opts.Add(BoolVariable('debug', 'enable HEAVY_DEBUG and disable optimizations', False))
 opts.Add(BoolVariable('enable_profiling', 'enable debug symbols for profiling purposes', True))
 opts.Add(BoolVariable('enable_i18n', 'enable i18n support for brushlib (requires gettext)', True))
@@ -56,6 +59,12 @@ if os.environ.has_key('LDFLAGS'):
    env['LINKFLAGS'] += SCons.Util.CLVar(os.environ['LDFLAGS'])
 
 opts.Update(env)
+
+for d in ('lib', 'include', 'data'):
+    key = d + 'dir'
+    val = env[key]
+    if not val.startswith(os.sep):
+        env[key] = os.path.join(env['prefix'], val)
 
 env.Append(CXXFLAGS=' -Wall -Wno-sign-compare -Wno-write-strings')
 env.Append(CCFLAGS='-Wall -Wstrict-prototypes -Werror')
@@ -94,7 +103,8 @@ def install_perms(env, target, sources, perms=0644, dirperms=0755):
     postaction.
 
     """
-    assert target.startswith('$prefix')
+    assert any(target.startswith(x) for x in (
+        "$prefix", "$libdir", "$includedir", "$datadir"))
     install_targs = env.Install(target, sources)
 
     # Set file permissions, and defer directory permission setting

--- a/SConstruct
+++ b/SConstruct
@@ -60,6 +60,7 @@ if os.environ.has_key('LDFLAGS'):
 
 opts.Update(env)
 
+# convert libdir, includedir, datadir to absolute paths if necessary
 for d in ('lib', 'include', 'data'):
     key = d + 'dir'
     val = env[key]

--- a/SConstruct
+++ b/SConstruct
@@ -63,7 +63,7 @@ opts.Update(env)
 for d in ('lib', 'include', 'data'):
     key = d + 'dir'
     val = env[key]
-    if not val.startswith(os.sep):
+    if not os.path.isabs(val):
         env[key] = os.path.join(env['prefix'], val)
 
 env.Append(CXXFLAGS=' -Wall -Wno-sign-compare -Wno-write-strings')

--- a/SConstruct
+++ b/SConstruct
@@ -24,9 +24,9 @@ opts.Add(
     default=default_prefix,
     validator=isabs,
 )
-opts.Add('libdir', 'Directory into which libraries are installed', default='lib')
-opts.Add('includedir', 'Directory into which headers are installed', default='include')
-opts.Add('datadir', 'Directory into which shared data is installed', default='share')
+opts.Add('libdir', 'Directory into which libraries are installed, absolute or relative to prefix', default='lib')
+opts.Add('includedir', 'Directory into which headers are installed, absolute or relative to prefix', default='include')
+opts.Add('datadir', 'Directory into which shared data is installed, absolute or relative to prefix', default='share')
 opts.Add(BoolVariable('debug', 'enable HEAVY_DEBUG and disable optimizations', False))
 opts.Add(BoolVariable('enable_profiling', 'enable debug symbols for profiling purposes', True))
 opts.Add(BoolVariable('enable_i18n', 'enable i18n support for brushlib (requires gettext)', True))


### PR DESCRIPTION
This allows e.g. installing libraries to arch-specific directories, like "/usr/lib64" for 64 bit on Fedora.