### PR TITLE
Standardize libmypaint build for both GIMP and MyPaint - version 2

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -79,11 +79,12 @@ top_env = env
 env = env.Clone()
 
 if env['enable_introspection']:
-    env['use_glib'] = True
-    env['use_sharedlib'] = True
-    print "Enabling glib because of enable_introspection=true"
+    if not env['use_glib']:
+        print "Enabling glib because of enable_introspection=true"
     if not env['use_sharedlib']:
         print "Building a shared lib instead of a static lib because of enable_introspection=true"
+    env['use_glib'] = True
+    env['use_sharedlib'] = True
 
 Export('env')
 

--- a/SConscript
+++ b/SConscript
@@ -82,7 +82,8 @@ if env['enable_introspection']:
     env['use_glib'] = True
     env['use_sharedlib'] = True
     print "Enabling glib because of enable_introspection=true"
-    print "Building a shared lib instead of a static lib because of enable_introspection=true"
+    if not env['use_sharedlib']:
+        print "Building a shared lib instead of a static lib because of enable_introspection=true"
 
 Export('env')
 

--- a/SConstruct
+++ b/SConstruct
@@ -32,7 +32,7 @@ opts.Add(BoolVariable('enable_introspection', 'enable GObject introspection supp
 opts.Add(BoolVariable('enable_docs', 'enable documentation build', False))
 opts.Add(BoolVariable('enable_gperftools', 'enable gperftools in build, for profiling', False))
 opts.Add(BoolVariable('enable_openmp', 'enable OpenMP for multithreaded processing', default_openmp))
-opts.Add(BoolVariable('use_sharedlib', 'build a shared library instead of a static library (forced on by introspection)', False))
+opts.Add(BoolVariable('use_sharedlib', 'build a shared library instead of a static library (forced on by introspection)', True))
 opts.Add(BoolVariable('use_glib', 'enable glib (forced on by introspection)', False))
 opts.Add('python_binary', 'python executable to build for', default_python_binary)
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -26,11 +26,12 @@ if testlib_env['enable_gperftools']:
     testlib_env.Append(CPPDEFINES='HAVE_GPERFTOOLS')
 
 lib_builder = testlib_env.SharedLibrary if env['use_sharedlib'] else testlib_env.StaticPicLibrary
-lib_builder(target='../mypaint-tests', source=testlib_sources)
+lib_builder(target='mypaint-tests', source=testlib_sources)
 
 tests_env = testlib_env.Clone()
 
 # Build individual tests
+tests_env.Append(LIBPATH=['.', '..'])
 tests_env['LIBS'].remove('mypaint') # Workaround: ordering wrong when using Prepend on some systems
 tests_env.Prepend(LIBS=['mypaint-tests', 'mypaint'])
 


### PR DESCRIPTION
Since the pull request 31 won't update anymore after the revert, here is a new pull request. I fixed the tests when libmypaint is built as a shared lib (now the `nosetests` command finishes with value 0 when run from tree root).