### PR TITLE
configure.ac: Correctly check $host

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,33 +73,26 @@ AM_MAINTAINER_MODE([enable])
 PKG_PROG_PKG_CONFIG(0.16)
 
 ###########################
-# Check target architecture
+# Check host architecture
 ###########################
 
-AC_MSG_CHECKING([for target architecture])
-case x"$target" in
-  xNONE | x)
-    target_or_host="$host" ;;
-  *)
-    target_or_host="$target" ;;
-esac
-AC_MSG_RESULT([$target_or_host])
+AC_CANONICAL_HOST
 
-case "$target_or_host" in
-  i*86-*-*)
+case "$host_cpu" in
+  i*86)
     have_x86=yes
     AC_DEFINE(ARCH_X86, 1, [Define to 1 if you are compiling for ix86.])
     ;;
-  x86_64-*-*)
+  x86_64)
     have_x86=yes
     AC_DEFINE(ARCH_X86, 1, [Define to 1 if you are compiling for ix86.])
     AC_DEFINE(ARCH_X86_64, 1, [Define to 1 if you are compiling for amd64.])
     ;;
-  ppc-*-* | powerpc-*)
+  ppc | powerpc)
     have_ppc=yes
     AC_DEFINE(ARCH_PPC, 1, [Define to 1 if you are compiling for PowerPC.])
     ;;
-  ppc64-*-* | powerpc64-*)
+  ppc64 | powerpc64)
     have_ppc=yes
     AC_DEFINE(ARCH_PPC, 1, [Define to 1 if you are compiling for PowerPC.])
     AC_DEFINE(ARCH_PPC64, 1, [Define to 1 if you are compiling for PowerPC64.])
@@ -113,8 +106,8 @@ esac
 #################
 
 AC_MSG_CHECKING([for some Win32 platform])
-case "$target_or_host" in
-  *-*-mingw* | *-*-cygwin*)
+case "$host_os" in
+  mingw* | cygwin*)
     platform_win32=yes
     ;;
   *)
@@ -125,11 +118,11 @@ AC_MSG_RESULT([$platform_win32])
 AM_CONDITIONAL(PLATFORM_WIN32, test "$platform_win32" = "yes")
 
 AC_MSG_CHECKING([for native Win32])
-case "$target_or_host" in
-  *-*-mingw*)
+case "$host_os" in
+  mingw*)
     os_win32=yes
-    case "$host" in
-      x86_64-*-*)
+    case "$host_cpu" in
+      x86_64)
 	;;
       *)
 	WIN32_LARGE_ADDRESS_AWARE='-Wl,--large-address-aware'
@@ -154,8 +147,8 @@ AM_CONDITIONAL(OS_UNIX, test "$os_win32" != "yes")
 
 platform_osx=no
 AC_MSG_CHECKING([if compiling for Mac OS X])
-case "$target_or_host" in
-  *-*-darwin*)
+case "$host_os" in
+  darwin*)
      AC_MSG_RESULT(yes)
      AC_DEFINE(PLATFORM_OSX, 1, [define to 1 if compiling for Mac OS X])
      platform_osx=yes


### PR DESCRIPTION
$target is meant for toolchain packages only, not for libraries.

Signed-off-by: Quentin Glidic <sardemff7+git@sardemff7.net>