### PR TITLE
py3k: Use new-style division.

### DIFF
--- a/doc/scripts/dab_hardness_plot.py
+++ b/doc/scripts/dab_hardness_plot.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 

--- a/examples/gegl.py
+++ b/examples/gegl.py
@@ -1,5 +1,5 @@
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
 from gi.repository import GeglGtk3 as GeglGtk
 from gi.repository import Gegl, Gtk

--- a/generate.py
+++ b/generate.py
@@ -18,7 +18,7 @@
 
 "Code generator, part of the build process."
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/tests/ctests.py
+++ b/tests/ctests.py
@@ -1,5 +1,5 @@
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 

--- a/tests/test_ctests.py
+++ b/tests/test_ctests.py
@@ -1,5 +1,5 @@
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 import ctests


### PR DESCRIPTION
This enables new-style division on Python 2. Actually, all cases used float division anyway, so this makes no difference to existing code. It will just ensure that any new code is consistent across Python versions.