### PR TITLE
Ascension values can go out of bounds

### DIFF
--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -500,7 +500,7 @@ smallest_angular_difference(float a, float b)
     inputs[MYPAINT_BRUSH_INPUT_STROKE] = MIN(self->states[MYPAINT_BRUSH_STATE_STROKE], 1.0);
     inputs[MYPAINT_BRUSH_INPUT_DIRECTION] = fmodf (atan2f (self->states[MYPAINT_BRUSH_STATE_DIRECTION_DY], self->states[MYPAINT_BRUSH_STATE_DIRECTION_DX])/(2*M_PI)*360 + 180.0, 180.0);
     inputs[MYPAINT_BRUSH_INPUT_TILT_DECLINATION] = self->states[MYPAINT_BRUSH_STATE_DECLINATION];
-    inputs[MYPAINT_BRUSH_INPUT_TILT_ASCENSION] = fmodf(abs(self->states[MYPAINT_BRUSH_STATE_ASCENSION] + 180), 360.0) - 180;
+    inputs[MYPAINT_BRUSH_INPUT_TILT_ASCENSION] = fmodf(abs(self->states[MYPAINT_BRUSH_STATE_ASCENSION] + 180.0), 360.0) - 180.0;
 
     inputs[MYPAINT_BRUSH_INPUT_CUSTOM] = self->states[MYPAINT_BRUSH_STATE_CUSTOM_INPUT];
     if (self->print_inputs) {

--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -500,11 +500,11 @@ smallest_angular_difference(float a, float b)
     inputs[MYPAINT_BRUSH_INPUT_STROKE] = MIN(self->states[MYPAINT_BRUSH_STATE_STROKE], 1.0);
     inputs[MYPAINT_BRUSH_INPUT_DIRECTION] = fmodf (atan2f (self->states[MYPAINT_BRUSH_STATE_DIRECTION_DY], self->states[MYPAINT_BRUSH_STATE_DIRECTION_DX])/(2*M_PI)*360 + 180.0, 180.0);
     inputs[MYPAINT_BRUSH_INPUT_TILT_DECLINATION] = self->states[MYPAINT_BRUSH_STATE_DECLINATION];
-    inputs[MYPAINT_BRUSH_INPUT_TILT_ASCENSION] = fmodf(self->states[MYPAINT_BRUSH_STATE_ASCENSION] + 180.0, 360.0) - 180.0;
+    inputs[MYPAINT_BRUSH_INPUT_TILT_ASCENSION] = fmodf(abs(self->states[MYPAINT_BRUSH_STATE_ASCENSION] + 180), 360.0) - 180;
 
     inputs[MYPAINT_BRUSH_INPUT_CUSTOM] = self->states[MYPAINT_BRUSH_STATE_CUSTOM_INPUT];
     if (self->print_inputs) {
-      printf("press=% 4.3f, speed1=% 4.4f\tspeed2=% 4.4f\tstroke=% 4.3f\tcustom=% 4.3f\n", (double)inputs[MYPAINT_BRUSH_INPUT_PRESSURE], (double)inputs[MYPAINT_BRUSH_INPUT_SPEED1], (double)inputs[MYPAINT_BRUSH_INPUT_SPEED2], (double)inputs[MYPAINT_BRUSH_INPUT_STROKE], (double)inputs[MYPAINT_BRUSH_INPUT_CUSTOM]);
+      printf("press=% 4.3f, speed1=% 4.4f\tspeed2=% 4.4f\tstroke=% 4.3f\tcustom=% 4.3f\tdir=% 4.3f\tdec=% 4.3f\tasc=% 4.3f\trnd=% 4.3f\tasc-state=% 4.3f\n", (double)inputs[MYPAINT_BRUSH_INPUT_PRESSURE], (double)inputs[MYPAINT_BRUSH_INPUT_SPEED1], (double)inputs[MYPAINT_BRUSH_INPUT_SPEED2], (double)inputs[MYPAINT_BRUSH_INPUT_STROKE], (double)inputs[MYPAINT_BRUSH_INPUT_CUSTOM], (double)inputs[MYPAINT_BRUSH_INPUT_DIRECTION], (double)inputs[MYPAINT_BRUSH_INPUT_TILT_DECLINATION], (double)inputs[MYPAINT_BRUSH_INPUT_TILT_ASCENSION],(double)inputs[MYPAINT_BRUSH_INPUT_RANDOM],(double)self->states[MYPAINT_BRUSH_STATE_ASCENSION]);
     }
     // FIXME: this one fails!!!
     //assert(inputs[MYPAINT_BRUSH_INPUT_SPEED1] >= 0.0 && inputs[MYPAINT_BRUSH_INPUT_SPEED1] < 1e8); // checking for inf


### PR DESCRIPTION
MYPAINT_BRUSH_STATE_ASCENSION seems to grow without bounds as it is constantly having values added and subtracted as the stylus is spun.  If this number becomes negative than the formula appears to fail and numbers beyond 360 degrees appear in the output logging.  Constraining MYPAINT_BRUSH_STATE_ASCENSION with abs() seems to fix the issue, but I have to wonder if it should be allowed to grow and grow over the course of a drawing.  You can basically wind it up or down by spinning your stylus like the hands on a clock.  I've added the remaining inputs to the console for outputting when debug inputs is enabled in the help menu.

Here ascension state matches ascension, everything normal:
![screenshot from 2016-07-24 10-02-37](https://cloud.githubusercontent.com/assets/6015639/17085273/395cef3a-5189-11e6-9d2d-a7166a6a8a61.png)

Here I've "winded it up" in a clockwise rotation by.  Acension-state is growing but ascension looks fine
![screenshot from 2016-07-24 10-03-23](https://cloud.githubusercontent.com/assets/6015639/17085291/72614e0c-5189-11e6-9788-83507418812b.png)

Here's I've winded it in a counter-clockwise rotation and now Ascension-state has gone into the negatives, which causes Ascension to get to weird values like -512 degrees:
![screenshot from 2016-07-24 10-04-21](https://cloud.githubusercontent.com/assets/6015639/17085309/a58b97c4-5189-11e6-86c0-b6308b880819.png)

Despite this oddness, I couldn't find any negative impact to the brush settings for Ascension so I guess it is being corrected w/ a modulo 180, maybe by the min/max in brushsettings.json? 

