### PR TITLE
correct the list of dependencies on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ On recent Debian-like systems, you can type the following
 to get started with a standard configuration:
 
     $ sudo apt install build-essential
-    $ sudo apt install libjson-c-dev libjson-c-dev libglib2.0-dev
+    $ sudo apt install libjson-c-dev libgirepository1.0-dev libglib2.0-dev
     $ sudo apt install python2 autotools intltool    # Building from git
 
 ## Build and install


### PR DESCRIPTION
Removing the duplicate dependency libjson-c-dev and add
the missing required dependency libgirepository1.0-dev.