### PR TITLE
doc: fix building with parallel build trees

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -7,9 +7,13 @@ if ENABLE_DOCS
 
 doxygen/index.xml: Doxyfile
 	mkdir -p doxygen && cd doxygen && \
-	$(DOXYGEN) ../Doxyfile
+	$(DOXYGEN) $(abs_srcdir)/Doxyfile
 
 build/index.html: doxygen/index.xml
+	@if test "$(abs_srcdir)" != "$(abs_builddir)"; then \
+		rm -rf source; \
+		cp -r $(srcdir)/source source; \
+	fi
 	$(SPHINX_BUILD) source/ build/
 
 all: build/index.html


### PR DESCRIPTION
This change fixes building in [parallel build trees](https://www.gnu.org/software/automake/manual/html_node/VPATH-Builds.html) AKA off-root builds.