### PR TITLE
Update git instructions for install on Debian/Ubuntu based machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ to get started with a standard configuration:
 
     $ sudo apt install -y build-essential
     $ sudo apt install -y libjson-c-dev libgirepository1.0-dev libglib2.0-dev
-    $ sudo apt install -y python2.7 autotools intltool gettext   # Building from git
-
-The last line for Ubuntu systems should be:
-
-    $ sudo apt install -y python2.7 autotools-dev intltool gettext
+    $ sudo apt install -y python2.7 autotools-dev intltool gettext   # Building from git
 
 ## Build and install
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ to get started with a standard configuration:
 
     $ sudo apt install -y build-essential
     $ sudo apt install -y libjson-c-dev libgirepository1.0-dev libglib2.0-dev
-    $ sudo apt install -y python2 autotools intltool gettext   # Building from git
+    $ sudo apt install -y python2.7 autotools intltool gettext   # Building from git
 
 The last line for Ubuntu systems should be:
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ License: ISC, see [COPYING](./COPYING) for details.
 On recent Debian-like systems, you can type the following
 to get started with a standard configuration:
 
-    $ sudo apt install build-essential
-    $ sudo apt install libjson-c-dev libgirepository1.0-dev libglib2.0-dev
-    $ sudo apt install python2 autotools intltool gettext   # Building from git
+    $ sudo apt install -y build-essential
+    $ sudo apt install -y libjson-c-dev libgirepository1.0-dev libglib2.0-dev
+    $ sudo apt install -y python2 autotools intltool gettext   # Building from git
+
+The last line for Ubuntu systems should be:
+
+    $ sudo apt install -y python2.7 autotools-dev intltool gettext
 
 ## Build and install
 


### PR DESCRIPTION
I note that the python2 dependency seems wrong in ubuntu based machines (it should be python2.7 at least), and same for autotools, the package is named autotools-dev. Probably in Debian are the old names, but I cannot ensure, only I can ensure for Ubuntu 16.10.

Also adding the -y to apt-get commands, so it is more easy to just copy & paste.