### PR TITLE
Make behavior of brushes independent from frequency of input device (when using random input)

### DIFF
--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -85,6 +85,7 @@ struct MyPaintBrush {
 
     // the states (get_state, set_state, reset) that change during a stroke
     float states[MYPAINT_BRUSH_STATES_COUNT];
+    double random_input;
     RngDouble * rng;
 
     // Those mappings describe how to calculate the current value for each setting.
@@ -130,6 +131,7 @@ mypaint_brush_new(void)
       self->settings[i] = mypaint_mapping_new(MYPAINT_BRUSH_INPUTS_COUNT);
     }
     self->rng = rng_double_new(1000);
+    self->random_input = 0;
     self->print_inputs = FALSE;
 
     for (i=0; i<MYPAINT_BRUSH_STATES_COUNT; i++) {
@@ -511,7 +513,7 @@ smallest_angular_difference(float angleA, float angleB)
     inputs[MYPAINT_BRUSH_INPUT_SPEED1] = log((self->speed_mapping_gamma[0] + self->states[MYPAINT_BRUSH_STATE_NORM_SPEED1_SLOW])*self->states[MYPAINT_BRUSH_STATE_VIEWZOOM])*self->speed_mapping_m[0] + self->speed_mapping_q[0], 0.0, 4.0;
     inputs[MYPAINT_BRUSH_INPUT_SPEED2] = log((self->speed_mapping_gamma[1] + self->states[MYPAINT_BRUSH_STATE_NORM_SPEED2_SLOW])*self->states[MYPAINT_BRUSH_STATE_VIEWZOOM])*self->speed_mapping_m[1] + self->speed_mapping_q[1], 0.0, 4.0;
     
-    inputs[MYPAINT_BRUSH_INPUT_RANDOM] = rng_double_next(self->rng);
+    inputs[MYPAINT_BRUSH_INPUT_RANDOM] = self->random_input;
     inputs[MYPAINT_BRUSH_INPUT_STROKE] = MIN(self->states[MYPAINT_BRUSH_STATE_STROKE], 1.0);
     //correct direction for varying view rotation
     inputs[MYPAINT_BRUSH_INPUT_DIRECTION] = fmodf(atan2f (self->states[MYPAINT_BRUSH_STATE_DIRECTION_DY], self->states[MYPAINT_BRUSH_STATE_DIRECTION_DX])/(2*M_PI)*360 + self->states[MYPAINT_BRUSH_STATE_VIEWROTATION] + 180.0, 180.0);
@@ -982,6 +984,9 @@ smallest_angular_difference(float angleA, float angleB)
     if (dtime > 5 || self->reset_requested) {
       self->reset_requested = FALSE;
 
+      // reset value of random input
+      self->random_input = rng_double_next(self->rng);
+
       //printf("Brush reset.\n");
       int i=0;
       for (i=0; i<MYPAINT_BRUSH_STATES_COUNT; i++) {
@@ -1036,6 +1041,9 @@ smallest_angular_difference(float angleA, float angleB)
       } else if (painted == UNKNOWN) {
         painted = NO;
       }
+
+      // update value of random input only when draw the dab
+      self->random_input = rng_double_next(self->rng);
 
       dtime_left   -= step_dtime;
       dabs_todo  = count_dabs_to (self, x, y, pressure, dtime_left);

--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -86,6 +86,10 @@ struct MyPaintBrush {
     // the states (get_state, set_state, reset) that change during a stroke
     float states[MYPAINT_BRUSH_STATES_COUNT];
     double random_input;
+    float skip;
+    float skip_last_x;
+    float skip_last_y;
+    float skipped_dtime;
     RngDouble * rng;
 
     // Those mappings describe how to calculate the current value for each setting.
@@ -132,6 +136,10 @@ mypaint_brush_new(void)
     }
     self->rng = rng_double_new(1000);
     self->random_input = 0;
+    self->skip = 0;
+    self->skip_last_x = 0;
+    self->skip_last_y = 0;
+    self->skipped_dtime = 0;
     self->print_inputs = FALSE;
 
     for (i=0; i<MYPAINT_BRUSH_STATES_COUNT; i++) {
@@ -910,6 +918,8 @@ smallest_angular_difference(float angleA, float angleB)
                                 float x, float y, float pressure,
                                 float xtilt, float ytilt, double dtime, float viewzoom, float viewrotation)
   {
+    const float max_dtime = 5;
+
     //printf("%f %f %f %f\n", (double)dtime, (double)x, (double)y, (double)pressure);
 
     float tilt_ascension = 0.0;
@@ -959,15 +969,45 @@ smallest_angular_difference(float angleA, float angleB)
       dtime = 0.0001;
     }
 
+    // skip some length of input if requested (for stable tracking noise)
+    if (self->skip > 0.001) {
+      float dist = hypotf(self->skip_last_x-x, self->skip_last_y-y);
+      self->skip_last_x = x;
+      self->skip_last_y = y;
+      self->skipped_dtime += dtime;
+      self->skip -= dist;
+      dtime = self->skipped_dtime;
+
+      if (self->skip > 0.001 && !(dtime > max_dtime || self->reset_requested))
+        return TRUE;
+
+      // skipped
+      self->skip = 0;
+      self->skip_last_x = 0;
+      self->skip_last_y = 0;
+      self->skipped_dtime = 0;
+    }
+
+
     { // calculate the actual "virtual" cursor position
 
       // noise first
       if (mypaint_mapping_get_base_value(self->settings[MYPAINT_BRUSH_SETTING_TRACKING_NOISE])) {
         // OPTIMIZE: expf() called too often
         const float base_radius = expf(mypaint_mapping_get_base_value(self->settings[MYPAINT_BRUSH_SETTING_RADIUS_LOGARITHMIC]));
+        const float noise = base_radius * mypaint_mapping_get_base_value(self->settings[MYPAINT_BRUSH_SETTING_TRACKING_NOISE]);
 
-        x += rand_gauss (self->rng) * mypaint_mapping_get_base_value(self->settings[MYPAINT_BRUSH_SETTING_TRACKING_NOISE]) * base_radius;
-        y += rand_gauss (self->rng) * mypaint_mapping_get_base_value(self->settings[MYPAINT_BRUSH_SETTING_TRACKING_NOISE]) * base_radius;
+        if (noise > 0.001) {
+          // we need to skip some length of input to make
+          // tracking noise independent from input frequency
+          self->skip = 0.5*noise;
+          self->skip_last_x = x;
+          self->skip_last_y = y;
+
+          // add noise
+          x += noise * rand_gauss(self->rng);
+          y += noise * rand_gauss(self->rng);
+        }
       }
 
       const float fac = 1.0 - exp_decay (mypaint_mapping_get_base_value(self->settings[MYPAINT_BRUSH_SETTING_SLOW_TRACKING]), 100.0*dtime);
@@ -981,8 +1021,14 @@ smallest_angular_difference(float angleA, float angleB)
     float dabs_moved = self->states[MYPAINT_BRUSH_STATE_PARTIAL_DABS];
     float dabs_todo = count_dabs_to (self, x, y, pressure, dtime);
 
-    if (dtime > 5 || self->reset_requested) {
+    if (dtime > max_dtime || self->reset_requested) {
       self->reset_requested = FALSE;
+
+      // reset skipping
+      self->skip = 0;
+      self->skip_last_x = 0;
+      self->skip_last_y = 0;
+      self->skipped_dtime = 0;
 
       // reset value of random input
       self->random_input = rng_double_next(self->rng);


### PR DESCRIPTION
I tried to use libmaypaint with smooth interpolation of input. I've passed into libmypaint strokes with one-pixel step. And then DNA and Fur brushes produce a thousands of dabs.

It's not happens when i use step size 30-60 pixels, which usually produced by raw input without any interpolation while using these brushes.

This patch makes behavior of brushes independent from input accuracy (frequency and step size).