### PR TITLE
input: barrel rotation.  Art Pen and other GTK WHEEL enabled inputs

### DIFF
--- a/brushsettings.json
+++ b/brushsettings.json
@@ -81,6 +81,17 @@
             "tooltip": "Right ascension of stylus tilt. 0 when stylus working end points to you, +90 when rotated 90 degrees clockwise, -90 when rotated 90 degrees counterclockwise."
         }, 
         {
+            "displayed_name": "Barrel Rotation", 
+            "hard_maximum": 180.0, 
+            "hard_minimum": -180.0, 
+            "id": "barrel_rotation", 
+            "normal": 0.0, 
+            "soft_maximum": 180.0, 
+            "soft_minimum": -180.0, 
+            "tooltip": "Barrel rotation of Stylus. 0 when not twisted +90 when twisted clockwise 90 degrees, -90 when twisted counterclockwise."
+        }, 
+
+        {
             "displayed_name": "Custom", 
             "hard_maximum": null, 
             "hard_minimum": null, 
@@ -529,6 +540,7 @@
         "direction_dx",
         "direction_dy",
         "declination",
-        "ascension"
+        "ascension",
+        "barrel_rotation"
     ]
 }

--- a/examples/minimal.c
+++ b/examples/minimal.c
@@ -5,10 +5,10 @@
 #include "utils.h" /* Not public API, just used for write_ppm to demonstrate */
 
 void
-stroke_to(MyPaintBrush *brush, MyPaintSurface *surf, float x, float y)
+stroke_to(MyPaintBrush *brush, MyPaintSurface *surf, float x, float y, float barrel_rotation)
 {
     float pressure = 1.0, ytilt = 0.0, xtilt = 0.0, dtime = 1.0/10;
-    mypaint_brush_stroke_to(brush, surf, x, y, pressure, xtilt, ytilt, dtime);
+    mypaint_brush_stroke_to(brush, surf, x, y, pressure, xtilt, ytilt, dtime, barrel_rotation);
 }
 
 int

--- a/mypaint-brush.h
+++ b/mypaint-brush.h
@@ -42,7 +42,7 @@ mypaint_brush_new_stroke(MyPaintBrush *self);
 
 int
 mypaint_brush_stroke_to(MyPaintBrush *self, MyPaintSurface *surface, float x, float y,
-                        float pressure, float xtilt, float ytilt, double dtime);
+                        float pressure, float xtilt, float ytilt, double dtime, float barrel_rotation);
 
 void
 mypaint_brush_set_base_value(MyPaintBrush *self, MyPaintBrushSetting id, float value);

--- a/tests/mypaint-utils-stroke-player.c
+++ b/tests/mypaint-utils-stroke-player.c
@@ -41,6 +41,7 @@ typedef struct {
     float pressure;
     float xtilt;
     float ytilt;
+    float barrel_rotation;
 } MotionEvent;
 
 struct MyPaintUtilsStrokePlayer {
@@ -103,8 +104,8 @@ mypaint_utils_stroke_player_set_source_data(MyPaintUtilsStrokePlayer *self, cons
     for (int i=0; i<self->number_of_events; i++) {
         MotionEvent *event = &self->events[i];
 
-        int matches = sscanf(line, "%f %f %f %f",
-                             &event->time, &event->x, &event->y, &event->pressure);
+        int matches = sscanf(line, "%f %f %f %f %f",
+                             &event->time, &event->x, &event->y, &event->pressure, &event->barrel_rotation);
         if (matches != 4) {
             event->valid = FALSE;
             fprintf(stderr, "Error: Unable to parse line '%s'\n", line);
@@ -113,6 +114,7 @@ mypaint_utils_stroke_player_set_source_data(MyPaintUtilsStrokePlayer *self, cons
         }
         event->xtilt = 0.0;
         event->ytilt = 0.0;
+        event->barrel_rotation = 0.0;
 
         line = strtok(NULL, "\n");
     }
@@ -142,7 +144,7 @@ mypaint_utils_stroke_player_iterate(MyPaintUtilsStrokePlayer *self)
         mypaint_brush_stroke_to(self->brush, self->surface,
                                 event->x*self->scale, event->y*self->scale,
                                 event->pressure,
-                                event->xtilt, event->ytilt, dtime);
+                                event->xtilt, event->ytilt, dtime, event->barrel_rotation);
 
         if (self->transaction_on_stroke) {
             mypaint_surface_end_atomic(self->surface, NULL);


### PR DESCRIPTION
If input is -1 from mypaint gui, it is ignored.  Range -180 to 180
We need a way to disable rotation since some devices report bogus
rotation values.  Needs updated MyPaint 
![screenshot from 2017-06-15 20-47-42](https://user-images.githubusercontent.com/6015639/27211331-70b1b3a0-520d-11e7-8d16-c732c0d9c16e.png)
