### PR TITLE
Version all installed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,8 @@ autom4te.cache/
 .libs/
 *.lo
 
-libmypaint.la
-gegl/libmypaint-gegl.la
+libmypaint-*.la
+gegl/libmypaint-gegl-*.la
 
 po/*.gmo
 po/Makefile*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,11 @@
-# How to Contribute to MyPaint
+# How to Contribute to libMyPaint
 
-MyPaint is a volunteer-run project, built and maintained by many
-contributors. We welcome new team members, and value feedback from
-artists using MyPaint. Most of our documentation for new contributors
-can be found on the wiki:
+libMyPaint is a volunteer-run project, built and maintained by many
+contributors. It is part of the wider MyPaint project. We welcome new
+team members, and value feedback from anyone using this library, whether
+they're artists using MyPaint and wanting new brush ending features, or
+third party app developers building cool stuff with libmypaint. Most of
+our documentation for new contributors can be found on the wiki:
 
 * [How to report issues][1] - **please read** if you came here from the issue tracker.
 * [Get Involved][2] - how you can help MyPaint improve and grow.
@@ -11,7 +13,14 @@ can be found on the wiki:
 Note that MyPaint is released with a [Contributor Code of Conduct][3].
 By participating in this project you agree to abide by its terms.
 
+## libMyPaint specifics
+
+This section will grow :smile:
+
+
+
+
 [1]: https://github.com/mypaint/mypaint/wiki/Reporting-Bugs
 [2]: https://github.com/mypaint/mypaint/wiki/Contributing
 [3]: CODE_OF_CONDUCT.md
-
+[4]: VERSIONING.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ INTROSPECTION_SCANNER_ARGS = \
     --warn-all \
     --pkg="glib-2.0" \
     --namespace="MyPaint" \
-    --nsversion="$(LIBMYPAINT_MAJOR_VERSION).$(LIBMYPAINT_MINOR_VERSION)" \
+    --nsversion="$(LIBMYPAINT_API_PLATFORM_VERSION)" \
     --identifier-prefix="MyPaint" \
     --symbol-prefix="mypaint_" \
     --add-include-path="$(srcdir)" \
@@ -54,12 +54,13 @@ introspection_sources = \
 	mypaint-tiled-surface.c			\
 	tilemap.c
 
-MyPaint-@LIBMYPAINT_MAJOR_VERSION@.@LIBMYPAINT_MINOR_VERSION@.gir: libmypaint.la Makefile
-MyPaint_@LIBMYPAINT_MAJOR_VERSION@_@LIBMYPAINT_MINOR_VERSION@_gir_INCLUDES = GObject-2.0 GLib-2.0
-MyPaint_@LIBMYPAINT_MAJOR_VERSION@_@LIBMYPAINT_MINOR_VERSION@_gir_CFLAGS = $(AM_CFLAGS) $(AM_CPPFLAGS)
-MyPaint_@LIBMYPAINT_MAJOR_VERSION@_@LIBMYPAINT_MINOR_VERSION@_gir_LIBS = libmypaint.la
-MyPaint_@LIBMYPAINT_MAJOR_VERSION@_@LIBMYPAINT_MINOR_VERSION@_gir_FILES = $(introspection_sources)
-INTROSPECTION_GIRS += MyPaint-@LIBMYPAINT_MAJOR_VERSION@.@LIBMYPAINT_MINOR_VERSION@.gir
+# CAUTION: some of these need to use the underscored API version string.
+MyPaint-@LIBMYPAINT_API_PLATFORM_VERSION@.gir: libmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@.la Makefile
+MyPaint_@LIBMYPAINT_API_PLATFORM_VERSION_UL@_gir_INCLUDES = GObject-2.0 GLib-2.0
+MyPaint_@LIBMYPAINT_API_PLATFORM_VERSION_UL@_gir_CFLAGS = $(AM_CFLAGS) $(AM_CPPFLAGS)
+MyPaint_@LIBMYPAINT_API_PLATFORM_VERSION_UL@_gir_LIBS = libmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@.la
+MyPaint_@LIBMYPAINT_API_PLATFORM_VERSION_UL@_gir_FILES = $(introspection_sources)
+INTROSPECTION_GIRS += MyPaint-@LIBMYPAINT_API_PLATFORM_VERSION@.gir
 
 girdir = $(datadir)/gir-1.0
 gir_DATA = $(INTROSPECTION_GIRS)
@@ -75,22 +76,23 @@ endif # HAVE_INTROSPECTION
 
 pkgconfigdir = $(libdir)/pkgconfig
 
-pkgconfig_DATA = libmypaint.pc
+pkgconfig_DATA = libmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@.pc
 
-## libmypaint ##
+## libmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@ ##
 
 AM_CFLAGS = $(JSON_CFLAGS) $(GLIB_CFLAGS)
 
 LIBS = $(JSON_LIBS) $(GLIB_LIBS) @LIBS@
 
-lib_LTLIBRARIES = libmypaint.la
+lib_LTLIBRARIES = libmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@.la
 
-libmypaint_la_LDFLAGS = \
-    -release @LIBMYPAINT_API_PLATFORM_VERSION@ \
+libmypaint_@LIBMYPAINT_API_PLATFORM_VERSION@_la_LDFLAGS = \
     -version-info @LIBMYPAINT_ABI_VERSION_INFO@ \
     -no-undefined
 
-libmypaint_publicdir = $(includedir)/libmypaint
+#    -release @LIBMYPAINT_API_PLATFORM_VERSION@
+
+libmypaint_publicdir = $(includedir)/libmypaint-$(LIBMYPAINT_API_PLATFORM_VERSION)
 
 nobase_libmypaint_public_HEADERS = \
 	mypaint-config.h				\
@@ -117,9 +119,9 @@ LIBMYPAINT_SOURCES = \
 	tilemap.c						\
 	utils.c
 
-libmypaint_la_SOURCES = $(libmypaint_public_HEADERS) $(LIBMYPAINT_SOURCES)
+libmypaint_@LIBMYPAINT_API_PLATFORM_VERSION@_la_SOURCES = $(libmypaint_public_HEADERS) $(LIBMYPAINT_SOURCES)
 
-DISTCLEANFILES = MyPaint-@LIBMYPAINT_MAJOR_VERSION@.@LIBMYPAINT_MINOR_VERSION@.gir.files
+DISTCLEANFILES = MyPaint-@LIBMYPAINT_API_PLATFORM_VERSION@.gir.files
 
 EXTRA_DIST = \
 	brushsettings.json				\

--- a/configure.ac
+++ b/configure.ac
@@ -1,27 +1,50 @@
 # AC_OPENMP requires autoconf >= 2.62.
 AC_PREREQ(2.62)
 
+
+## Canonical version number components ##
+
 # API version: see https://github.com/mypaint/libmypaint/wiki/Versioning
+# See http://semver.org/ for what this means.
+
 m4_define([libmypaint_api_major], [2])
 m4_define([libmypaint_api_minor], [0])
 m4_define([libmypaint_api_micro], [0])
 m4_define([libmypaint_api_prerelease], [alpha])  # may be blank
-# The platform version is "major.minor" only.
-# The full version is "major.minor.micro[-prerelease]".
 
-# ABI version see: https://autotools.io/libtool/version.html
+# ABI version. Changes independently of API version.
+# See: https://autotools.io/libtool/version.html
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+# The rules are fiddly, and are summarized here.
+
 m4_define([libmypaint_abi_revision], [0])  # increment on every release
 m4_define([libmypaint_abi_current], [0])  # inc when add/remove/change interfaces
 m4_define([libmypaint_abi_age], [0])  # inc only if changes backward compat
 
-# Derivative version macros
+
+## Derivative version macros ##
+
+# The full version is "major.minor.micro[-prerelease]".
+
 m4_define([libmypaint_version],
           [libmypaint_api_major.libmypaint_api_minor.libmypaint_api_micro])
 m4_define([libmypaint_version_full],
           [libmypaint_api_major().libmypaint_api_minor().libmypaint_api_micro()m4_bpatsubst(libmypaint_api_prerelease(), [^\(.\)], [-\1])])
 
-# Dependencies.
+# The API "platform" or "intercompatibility" version.
+#
+# This one is used for library name prefixes, for introspection
+# namespace versions, for gettext domains, and basically anything that
+# needs to change when backwards or forwards API compatibility changes.
+# Another way of thinking about it: it allows meaningful side by side
+# installations of libmypaint.
+
+m4_define([libmypaint_api_platform_version],
+          [libmypaint_api_major.libmypaint_api_minor])
+
+
+## Dependencies ##
+
 m4_define([gegl_required_version], [0.3])
 m4_define([introspection_required_version], [1.32.0])
 
@@ -44,7 +67,8 @@ LIBMYPAINT_MINOR_VERSION=libmypaint_api_minor
 LIBMYPAINT_MICRO_VERSION=libmypaint_api_micro
 LIBMYPAINT_VERSION=libmypaint_version
 LIBMYPAINT_VERSION_FULL=libmypaint_version_full
-LIBMYPAINT_API_PLATFORM_VERSION=libmypaint_api_major.libmypaint_api_minor
+LIBMYPAINT_API_PLATFORM_VERSION=libmypaint_api_platform_version
+LIBMYPAINT_API_PLATFORM_VERSION_UL=m4_bpatsubst(libmypaint_api_platform_version(), [[^A-Za-z0-9]], [_])
 LIBMYPAINT_ABI_VERSION_INFO=libmypaint_abi_current:libmypaint_abi_revision:libmypaint_abi_age
 
 AC_SUBST(LIBMYPAINT_MAJOR_VERSION)
@@ -54,6 +78,7 @@ AC_SUBST(LIBMYPAINT_PRERELEASE_VERSION)
 AC_SUBST(LIBMYPAINT_VERSION)
 AC_SUBST(LIBMYPAINT_VERSION_FULL)
 AC_SUBST(LIBMYPAINT_API_PLATFORM_VERSION)
+AC_SUBST(LIBMYPAINT_API_PLATFORM_VERSION_UL)
 AC_SUBST(LIBMYPAINT_ABI_VERSION_INFO)
 
 AC_PROG_CC
@@ -72,9 +97,8 @@ AM_MAINTAINER_MODE([enable])
 # Check for pkg-config
 PKG_PROG_PKG_CONFIG(0.16)
 
-###########################
-# Check host and platform
-###########################
+
+## Check host and platform ##
 
 AC_CANONICAL_HOST
 
@@ -210,7 +234,7 @@ AC_ARG_ENABLE(i18n,
 
 if test "x$enable_i18n" != "xno"; then
   enable_i18n="yes"
-  GETTEXT_PACKAGE=libmypaint
+  GETTEXT_PACKAGE=libmypaint-libmypaint_api_platform_version
   AC_SUBST(GETTEXT_PACKAGE)
   AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE",
                      [The prefix for our gettext translation domains.])
@@ -258,9 +282,9 @@ AC_SUBST(PKG_CONFIG_REQUIRES)
 
 AC_CONFIG_FILES([
   doc/Makefile
-  gegl/libmypaint-gegl.pc:gegl/libmypaint-gegl.pc.in
+  gegl/libmypaint-gegl-]libmypaint_api_platform_version()[.pc:gegl/libmypaint-gegl.pc.in
   gegl/Makefile
-  libmypaint.pc:libmypaint.pc.in
+  libmypaint-]libmypaint_api_platform_version()[.pc:libmypaint.pc.in
   m4macros/Makefile
   Makefile
   po/Makefile.in

--- a/libmypaint.pc.in
+++ b/libmypaint.pc.in
@@ -8,5 +8,5 @@ Description: MyPaint's brushstroke rendering library (@LIBMYPAINT_VERSION_FULL@)
 URL: @PACKAGE_URL@
 Version: @LIBMYPAINT_VERSION@
 Requires: @PKG_CONFIG_REQUIRES@
-Cflags: -I${includedir}/libmypaint
-Libs: -L${libdir} -lmypaint @OPENMP_CFLAGS@
+Cflags: -I${includedir}/libmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@
+Libs: -L${libdir} -lmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@ @OPENMP_CFLAGS@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,7 +41,7 @@ endif
 LDADD = \
 	$(DEPS)							\
 	libmypaint-tests.a				\
-	$(top_builddir)/libmypaint.la
+	$(top_builddir)/libmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@.la
 
 EXTRA_DIST = \
 	brushes/bulk.myb			\


### PR DESCRIPTION
This should address the remaining aspects of #92 from the limited perspective of what gets installed. Please could everyone with a stake in this (@mitchfoo, @schumaml, @mypaint/developers, @mypaint/packagers) offer a speedy review so that I can merge the consequences of this rather far-reaching change into mypaint, libmypaint.deb, and MINGW-packages?

The resulting install layout within a prefix is as listed below, which allows multiple side-by-side libmypaint installations at the minor API version as requested by @mitchfoo.

Note to self: the gettext domain has changed. I'll need to check this actually works, with the right tweaks, in MyPaint proper so that I can discount the stuff that glib and gtk do as being from the bronze age. Are hyphens and dots in gettext domains acceptable?

```
lrwxrwxrwx ./lib/libmypaint-2.0.so -> libmypaint-2.0.so.0.0.0
-rwxr-xr-x ./lib/libmypaint-2.0.la  
-rw-r--r-- ./lib/girepository-1.0/MyPaint-2.0.typelib  
-rwxr-xr-x ./lib/libmypaint-2.0.so.0.0.0  
-rw-r--r-- ./lib/pkgconfig/libmypaint-2.0.pc  
lrwxrwxrwx ./lib/libmypaint-2.0.so.0 -> libmypaint-2.0.so.0.0.0
-rw-r--r-- ./include/libmypaint-2.0/mypaint-config.h  
-rw-r--r-- ./include/libmypaint-2.0/mypaint-brush-settings-gen.h  
-rw-r--r-- ./include/libmypaint-2.0/mypaint-brush.h  
-rw-r--r-- ./include/libmypaint-2.0/mypaint-surface.h  
-rw-r--r-- ./include/libmypaint-2.0/mypaint-tiled-surface.h  
-rw-r--r-- ./include/libmypaint-2.0/mypaint-rectangle.h  
-rw-r--r-- ./include/libmypaint-2.0/mypaint-brush-settings.h  
-rw-r--r-- ./include/libmypaint-2.0/mypaint-mapping.h  
-rw-r--r-- ./include/libmypaint-2.0/mypaint-fixed-tiled-surface.h  
-rw-r--r-- ./include/libmypaint-2.0/mypaint-glib-compat.h  
-rw-r--r-- ./share/locale/[...]/LC_MESSAGES/libmypaint-2.0.mo 
-rw-r--r-- ./share/gir-1.0/MyPaint-2.0.gir  
```