### PR TITLE
Mapping: avoid redundant interpolation

### DIFF
--- a/mypaint-mapping.c
+++ b/mypaint-mapping.c
@@ -174,7 +174,7 @@ float mypaint_mapping_calculate (MyPaintMapping * self, float * data)
           y1 = p->yvalues[i];
         }
 
-        if (x0 == x1) {
+        if (x0 == x1 || y0 == y1) {
           y = y0;
         } else {
           // linear interpolation


### PR DESCRIPTION
This wasn't the fix for the crash I was having in gridmap , but made it less likely.  So I'm inclined to believe it reduces a lot of unneeded interpolations for certain mapping patterns (anything with flat areas)

closes #99 