### PR TITLE
input: Base Brush Radius

### DIFF
--- a/brushsettings.json
+++ b/brushsettings.json
@@ -111,6 +111,16 @@
             "tooltip": "The current zoom level of the canvas view.  Logarithmic: 100% is 0.  200% is .69, 25% is -1.38\nFor Radius Setting, try dragging the slider to -4.15 to create a brush that stays the same size at (almost) every zoom level."
         },  
         {
+            "displayed_name": "Base Brush Radius", 
+            "hard_maximum": 6.0, 
+            "hard_minimum": -2.0, 
+            "id": "brush_radius", 
+            "normal": 0.0, 
+            "soft_maximum": 6.0, 
+            "soft_minimum": -2.0, 
+            "tooltip": "The base brush radius of the current brush.  This allows you to change the behavior of a brush as you make it bigger or smaller.\nYou can even cancel-out dab size increase and adjust something else to make a brush bigger.\nTake note of dabs-per-basic radius and dabs-per-actual radius, which behave much differently."
+        }, 
+        {
             "displayed_name": "Custom", 
             "hard_maximum": null, 
             "hard_minimum": null, 

--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -537,6 +537,7 @@ smallest_angular_difference(float angleA, float angleB)
     inputs[MYPAINT_BRUSH_INPUT_TILT_ASCENSION] = mod(self->states[MYPAINT_BRUSH_STATE_ASCENSION] + self->states[MYPAINT_BRUSH_STATE_VIEWROTATION] + 180.0, 360.0) - 180.0;
     inputs[MYPAINT_BRUSH_INPUT_VIEWZOOM] = (mypaint_mapping_get_base_value(self->settings[MYPAINT_BRUSH_SETTING_RADIUS_LOGARITHMIC])) - logf(base_radius * 1 / self->states[MYPAINT_BRUSH_STATE_VIEWZOOM]);
     inputs[MYPAINT_BRUSH_INPUT_ATTACK_ANGLE] = smallest_angular_difference(self->states[MYPAINT_BRUSH_STATE_ASCENSION], mod(atan2f(self->states[MYPAINT_BRUSH_STATE_DIRECTION_ANGLE_DY], self->states[MYPAINT_BRUSH_STATE_DIRECTION_ANGLE_DX]) / (2 * M_PI) * 360 + 90, 360));
+    inputs[MYPAINT_BRUSH_INPUT_BRUSH_RADIUS] = mypaint_mapping_get_base_value(self->settings[MYPAINT_BRUSH_SETTING_RADIUS_LOGARITHMIC]);
 
     inputs[MYPAINT_BRUSH_INPUT_CUSTOM] = self->states[MYPAINT_BRUSH_STATE_CUSTOM_INPUT];
     if (self->print_inputs) {


### PR DESCRIPTION
This input can help solve the following issues:
* pixel-feather/hardness drop-out with small brush sizes
* slow performance of small brushes due to many dabs
* blurry large brushes

It also brings to the table some new dimensions for brushes:
* Change any brush settings based on size
* Redefine bigger/smaller brush concept

Demo of this input applied to radius, smudge, and lightness.  No pressure, tilt, or any other input was used, all I did was use the F and D keys to make the brush bigger or smaller.  I've defined this brush so that it is darker when small, and more smudgy when large.  Also the dab size stays consistent and jitter makes the brush larger (instead of the dab size making it larger).  Finally, there are more dabs drawn when it is larger and less dabs when it is smaller.
![brushradius](https://user-images.githubusercontent.com/6015639/28952385-c4f96cde-7885-11e7-817c-f7352ee5ea61.jpg)

Probably the simplest and lamest-sounding input ever, but it is surprisingly useful.  This input is literally a feedback of the currently set base brush radius; the setting controlled by the sliders and buttons to make the brush bigger and smaller.

Bigger or Smaller, that is the question.  What do those terms mean for a brush in MyPaint?  Does it mean bigger dabs, or does it mean more dabs spread out over a bigger distance?  Or something else entirely?  Have you ever been disappointed by the way certain brushes look when you make them "bigger or smaller"?  I bet you have!  Here's the default devaad pencil when you make it bigger:
![image](https://user-images.githubusercontent.com/6015639/28892545-359a9278-7783-11e7-9015-5d4c5f4f32f7.png)

It gets all blurry and... well, not very much like a pencil anymore.  Here's the same pencil but with this new input set to mostly cancel-out the dab-size increase:
![image](https://user-images.githubusercontent.com/6015639/28892754-d90cfaa4-7783-11e7-9563-db55729564be.png)

![image](https://user-images.githubusercontent.com/6015639/28892802-0006cf7c-7784-11e7-89a6-0107bd136b99.png)

What's happening?!  Well, effectively as I make the brush bigger, I'm making it smaller again.  I can adjust this so that it completely negates the dab size growth, or just changes it slightly, or even amplify it to grow more, etc etc.

The interesting bit is that other aspects of the brush engine use the base brush radius value (as opposed to actual) for their calculations.  Things like jitter, and the offsets, among others.  Most importantly: the dabs-per-actual and basic radius settings use different brush sizes (if that's not obvious by the name).  If you use dabs-per-actual radius combined with this new input, you can easily make a brush that gets MORE dabs when it is bigger, and LESS dabs when it is smaller.  Previously the opposite would happen because as your brush was smaller the dab count would increase, which never made a lot of sense to me.  This also would cause small brushes to have horrible performance in some cases.  No more! Alternatively, you can use dab-per-basic radius (instead of actual) and keep the number of dabs consistent regardless of your brush size, making bigger brushes sparse (probably not what you usually want).

So try it out on those pesky brushes that you just hate to make bigger or smaller.  Of course, you can use this input to control other aspects of the brush.  Have you ever had a brush disappear when you make it small?  That's probably because you are using pixel feathering and/or hardness.  So, with this new input just fix it-- make pixel-feathering decrease and the hardness increase as you decrease the size of the brush.  

And you can make really useful "combo" brushes.  When the brush is small you can have a totally different overall behavior than when you make it bigger, and have it smoothly transition between the modes if you want.  This can be more useful than two brushes specifically because you can create very smooth transitions.

The last thing that that makes this nice is that you can just use the keyboard shortcuts, which means this input lets you do a lot more stuff dynamically without any need for a fancy tablet, tilt, or pressure.  I've made a feature issue on MyPaint to allow Custom input to have keyboard shortcuts too, which is along these same lines.