### PR TITLE
Sort input file list

### DIFF
--- a/tests/test_ctests.py
+++ b/tests/test_ctests.py
@@ -16,7 +16,7 @@ def is_ctest(fn):
 def test_libmypaint():
     c_tests = [
         os.path.abspath(os.path.join(tests_dir, fn))
-        for fn in os.listdir(tests_dir)
+        for fn in sorted(os.listdir(tests_dir))
         if is_ctest(fn)
     ]
 


### PR DESCRIPTION
so that libmypaint builds in a reproducible way
in spite of indeterministic filesystem readdir order

because .c files become .o files that get linked into a .so
and functions are ordered depending on that.

See https://reproducible-builds.org/ for why this matters.