### PR TITLE
Smudge_length_log setting and longer stroke

### DIFF
--- a/brushsettings.json
+++ b/brushsettings.json
@@ -484,11 +484,11 @@
             "tooltip": "This controls how fast the smudge color becomes the color you are painting on.\n0.0 immediately update the smudge color (requires more CPU cycles because of the frequent color checks)\n0.5 change the smudge color steadily towards the canvas color\n1.0 never change the smudge color"
         },
         {
-            "constant": true,
+            "constant": false,
             "default": 0.0,
             "displayed_name": "Smudge length multiplier",
             "internal_name": "smudge_length_log",
-            "maximum": 10.0,
+            "maximum": 20.0,
             "minimum": 0.0,
             "tooltip": "Lengthens the smudge_length, logarithmic\nUseful to correct for high-definition/large brushes with lots of dabs"
         },

--- a/brushsettings.json
+++ b/brushsettings.json
@@ -484,6 +484,15 @@
             "tooltip": "This controls how fast the smudge color becomes the color you are painting on.\n0.0 immediately update the smudge color (requires more CPU cycles because of the frequent color checks)\n0.5 change the smudge color steadily towards the canvas color\n1.0 never change the smudge color"
         },
         {
+            "constant": true,
+            "default": 0.0,
+            "displayed_name": "Smudge length multiplier",
+            "internal_name": "smudge_length_log",
+            "maximum": 10.0,
+            "minimum": 0.0,
+            "tooltip": "Lengthens the smudge_length, logarithmic\nUseful to correct for high-definition/large brushes with lots of dabs"
+        },
+        {
             "constant": false,
             "default": 0.0,
             "displayed_name": "Smudge radius",
@@ -515,7 +524,7 @@
             "default": 4.0,
             "displayed_name": "Stroke duration",
             "internal_name": "stroke_duration_logarithmic",
-            "maximum": 7.0,
+            "maximum": 14.0,
             "minimum": -1.0,
             "tooltip": "How far you have to move until the stroke input reaches 1.0. This value is logarithmic (negative values will not invert the process)."
         },

--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -803,17 +803,15 @@ smallest_angular_difference(float angleA, float angleB)
         b = self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_B];
         a = self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_A];
       }
-      //only update smudge_state if we actually picked a new color from canvas, but preserve old behavior for backwards compatibility
-      if (self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] == 1.0 || self->settings_value[MYPAINT_BRUSH_SETTING_SMUDGE_LENGTH_LOG] == 0.0) {
-        // updated the smudge color (stored with premultiplied alpha)
-        self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] + (1-fac)*a;
-        // fix rounding errors
-        self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] = CLAMP(self->states[MYPAINT_BRUSH_STATE_SMUDGE_A], 0.0, 1.0);
+      // updated the smudge color (stored with premultiplied alpha)
+      self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] + (1-fac)*a;
+      // fix rounding errors
+      self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] = CLAMP(self->states[MYPAINT_BRUSH_STATE_SMUDGE_A], 0.0, 1.0);
 
-        self->states[MYPAINT_BRUSH_STATE_SMUDGE_RA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_RA] + (1-fac)*r*a;
-        self->states[MYPAINT_BRUSH_STATE_SMUDGE_GA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_GA] + (1-fac)*g*a;
-        self->states[MYPAINT_BRUSH_STATE_SMUDGE_BA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_BA] + (1-fac)*b*a;
-      }
+      self->states[MYPAINT_BRUSH_STATE_SMUDGE_RA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_RA] + (1-fac)*r*a;
+      self->states[MYPAINT_BRUSH_STATE_SMUDGE_GA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_GA] + (1-fac)*g*a;
+      self->states[MYPAINT_BRUSH_STATE_SMUDGE_BA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_BA] + (1-fac)*b*a;
+      
     }
 
     // color part

--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -782,7 +782,7 @@ smallest_angular_difference(float angleA, float angleB)
       // second dab.
       float r, g, b, a;
       self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] *= fac;
-      if (self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] < 0.5*fac) {
+      if (self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] < 0.5*fac*powf(1000, -self->settings_value[MYPAINT_BRUSH_SETTING_SMUDGE_LENGTH_LOG])) {
         if (self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] == 0.0) {
           // first initialization of smudge color
           fac = 0.0;
@@ -803,15 +803,17 @@ smallest_angular_difference(float angleA, float angleB)
         b = self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_B];
         a = self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_A];
       }
+      //only update smudge_state if we actually picked a new color from canvas, but preserve old behavior for backwards compatibility
+      if (self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] == 1.0 || self->settings_value[MYPAINT_BRUSH_SETTING_SMUDGE_LENGTH_LOG] == 0.0) {
+        // updated the smudge color (stored with premultiplied alpha)
+        self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] + (1-fac)*a;
+        // fix rounding errors
+        self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] = CLAMP(self->states[MYPAINT_BRUSH_STATE_SMUDGE_A], 0.0, 1.0);
 
-      // updated the smudge color (stored with premultiplied alpha)
-      self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] + (1-fac)*a;
-      // fix rounding errors
-      self->states[MYPAINT_BRUSH_STATE_SMUDGE_A ] = CLAMP(self->states[MYPAINT_BRUSH_STATE_SMUDGE_A], 0.0, 1.0);
-
-      self->states[MYPAINT_BRUSH_STATE_SMUDGE_RA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_RA] + (1-fac)*r*a;
-      self->states[MYPAINT_BRUSH_STATE_SMUDGE_GA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_GA] + (1-fac)*g*a;
-      self->states[MYPAINT_BRUSH_STATE_SMUDGE_BA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_BA] + (1-fac)*b*a;
+        self->states[MYPAINT_BRUSH_STATE_SMUDGE_RA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_RA] + (1-fac)*r*a;
+        self->states[MYPAINT_BRUSH_STATE_SMUDGE_GA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_GA] + (1-fac)*g*a;
+        self->states[MYPAINT_BRUSH_STATE_SMUDGE_BA] = fac*self->states[MYPAINT_BRUSH_STATE_SMUDGE_BA] + (1-fac)*b*a;
+      }
     }
 
     // color part

--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -782,7 +782,7 @@ smallest_angular_difference(float angleA, float angleB)
       // second dab.
       float r, g, b, a;
       self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] *= fac;
-      if (self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] < 0.5*fac*powf(1000, -self->settings_value[MYPAINT_BRUSH_SETTING_SMUDGE_LENGTH_LOG])) {
+      if (self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] < (0.5*fac*powf(1000.0, -self->settings_value[MYPAINT_BRUSH_SETTING_SMUDGE_LENGTH_LOG])) + 0.0000000000000001) {
         if (self->states[MYPAINT_BRUSH_STATE_LAST_GETCOLOR_RECENTNESS] == 0.0) {
           // first initialization of smudge color
           fac = 0.0;


### PR DESCRIPTION
Since we've started allowing LOTS of dabs to accommodate nifty offset brushes, we need a way to extend the smudge_length.  For backwards compatibility I added a new setting Smudge Length Multiply.  Default of 0 preserves existing behavior 100%, but >0 will extend the smudge length on a log scale.  >0 will also change the criteria for updating the smudge state; normally smudge state is updated every single dab, which makes long smudges impossible. So, >0 only updates the smudge state when an actual get_color is called and there is a new color to mix with.

Here's a demo showing why this is necessary: https://youtu.be/g5lpVvzV81s
The view is 25% zoom so this brush is quite large with LOTS of small dabs.  When smudge_length_log==0 the smudge length is very short (even though smudge_length is set to .99).

Also expanded the max range of stroke_length from 7 to 14 for the same reasons, to allow longer strokes.  No compatibility issues with this either.