### PR TITLE
Don't require m4macros directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -149,7 +149,6 @@ endif
 
 SUBDIRS = \
 	.			\
-	m4macros	\
 	doc			\
 	gegl		\
 	tests		\

--- a/configure.ac
+++ b/configure.ac
@@ -285,7 +285,6 @@ AC_CONFIG_FILES([
   gegl/libmypaint-gegl-]libmypaint_api_platform_version()[.pc:gegl/libmypaint-gegl.pc.in
   gegl/Makefile
   libmypaint-]libmypaint_api_platform_version()[.pc:libmypaint.pc.in
-  m4macros/Makefile
   Makefile
   po/Makefile.in
   tests/Makefile

--- a/m4macros/Makefile.am
+++ b/m4macros/Makefile.am
@@ -1,5 +1,0 @@
-uinstalled_m4 = \
-	introspection.m4	\
-	pythondev.m4
-
-EXTRA_DIST = $(uninstalled_m4)


### PR DESCRIPTION
If you have [autoconf-archive](https://www.gnu.org/software/autoconf-archive/) installed, then you shouldn't need the `m4macros` directory. So here's a patch to make that possible.