### PR TITLE
Misc. trivial source comment typos

### DIFF
--- a/brushmodes.c
+++ b/brushmodes.c
@@ -31,7 +31,7 @@
 //       time. The mask is LRE encoded to jump quickly over regions
 //       that are not affected by the dab.
 //
-// opacity: overall strenght of the blending mode. Has the same
+// opacity: overall strength of the blending mode. Has the same
 //          influence on the dab as the values inside the mask.
 
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1660,7 +1660,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS
 # threshold limits the number of items for each type to make the size more
-# managable. Set this to 0 for no limit. Note that the threshold may be
+# manageable. Set this to 0 for no limit. Note that the threshold may be
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -414,13 +414,13 @@ smallest_angular_difference(float angleA, float angleB)
     // precalculate stuff that does not change dynamically
 
     // Precalculate how the physical speed will be mapped to the speed input value.
-    // The forumla for this mapping is:
+    // The formula for this mapping is:
     //
     // y = log(gamma+x)*m + q;
     //
     // x: the physical speed (pixels per basic dab radius)
     // y: the speed input that will be reported
-    // gamma: parameter set by ths user (small means a logarithmic mapping, big linear)
+    // gamma: parameter set by the user (small means a logarithmic mapping, big linear)
     // m, q: parameters to scale and translate the curve
     //
     // The code below calculates m and q given gamma and two hardcoded constraints.
@@ -658,7 +658,7 @@ smallest_angular_difference(float angleA, float angleB)
     if (self->states[MYPAINT_BRUSH_STATE_ACTUAL_RADIUS] < ACTUAL_RADIUS_MIN) self->states[MYPAINT_BRUSH_STATE_ACTUAL_RADIUS] = ACTUAL_RADIUS_MIN;
     if (self->states[MYPAINT_BRUSH_STATE_ACTUAL_RADIUS] > ACTUAL_RADIUS_MAX) self->states[MYPAINT_BRUSH_STATE_ACTUAL_RADIUS] = ACTUAL_RADIUS_MAX;
 
-    // aspect ratio (needs to be caluclated here because it can affect the dab spacing)
+    // aspect ratio (needs to be calculated here because it can affect the dab spacing)
     self->states[MYPAINT_BRUSH_STATE_ACTUAL_ELLIPTICAL_DAB_RATIO] = self->settings_value[MYPAINT_BRUSH_SETTING_ELLIPTICAL_DAB_RATIO];
     //correct dab angle for view rotation
     self->states[MYPAINT_BRUSH_STATE_ACTUAL_ELLIPTICAL_DAB_ANGLE] = mod(self->settings_value[MYPAINT_BRUSH_SETTING_ELLIPTICAL_DAB_ANGLE] - self->states[MYPAINT_BRUSH_STATE_VIEWROTATION] + 180.0, 180.0) - 180.0;
@@ -874,7 +874,7 @@ smallest_angular_difference(float angleA, float angleB)
 
     // HSL color change
     if (self->settings_value[MYPAINT_BRUSH_SETTING_CHANGE_COLOR_L] || self->settings_value[MYPAINT_BRUSH_SETTING_CHANGE_COLOR_HSL_S]) {
-      // (calculating way too much here, can be optimized if neccessary)
+      // (calculating way too much here, can be optimized if necessary)
       // this function will CLAMP the inputs
       hsv_to_rgb_float (&color_h, &color_s, &color_v);
       rgb_to_hsl_float (&color_h, &color_s, &color_v);
@@ -926,7 +926,7 @@ smallest_angular_difference(float angleA, float angleB)
       if (snapToPixel > 0.9999 )
       {
         snapped_radius -= 0.0001; // this fixes precision issues where
-                                  // neighboor pixels could be wrongly painted
+                                  // neighbor pixels could be wrongly painted
       }
 
       radius = radius + (snapped_radius - radius) * snapToPixel;
@@ -1239,7 +1239,7 @@ smallest_angular_difference(float angleA, float angleB)
       } else {
         // Usually we have pressure==0 here. But some brushes can paint
         // nothing at full pressure (eg gappy lines, or a stroke that
-        // fades out). In either case this is the prefered moment to split.
+        // fades out). In either case this is the preferred moment to split.
         if (self->stroke_total_painting_time+self->stroke_current_idling_time > 0.9 + 5*pressure) {
           return TRUE;
         }

--- a/mypaint-tiled-surface.c
+++ b/mypaint-tiled-surface.c
@@ -98,7 +98,7 @@ mypaint_tiled_surface_end_atomic(MyPaintTiledSurface *self, MyPaintRectangle *ro
  * mypaint_tiled_surface_tile_request_start:
  *
  * Fetch a tile out from the underlying tile store.
- * When successfull, request->data will be set to point to the fetched tile.
+ * When successful, request->data will be set to point to the fetched tile.
  * Consumers must *always* call mypaint_tiled_surface_tile_request_end() with the same
  * request to complete the transaction.
  */

--- a/mypaint-tiled-surface.h
+++ b/mypaint-tiled-surface.h
@@ -23,7 +23,7 @@ typedef struct {
     int ty;
     gboolean readonly;
     guint16 *buffer;
-    gpointer context; /* Only to be used by the surface implemenations. */
+    gpointer context; /* Only to be used by the surface implementations. */
     int thread_id;
     int mipmap_level;
 } MyPaintTileRequest;

--- a/operationqueue.c
+++ b/operationqueue.c
@@ -206,7 +206,7 @@ operation_queue_add(OperationQueue *self, TileIndex index, OperationDataDrawDab 
 }
 
 /* Pop an operation off the queue for tile @index
- * The user of this function is reponsible for freeing the result using free()
+ * The user of this function is responsible for freeing the result using free()
  *
  * Concurrency: This function is reentrant (and lock-free) on different @index */
 OperationDataDrawDab *

--- a/utils.c
+++ b/utils.c
@@ -48,7 +48,7 @@ typedef void (*LineChunkCallback) (uint16_t *chunk, int chunk_length, void *user
 
 /* Iterate over chunks of data in the MyPaintTiledSurface,
     starting top-left (0,0) and stopping at bottom-right (width-1,height-1)
-    callback will be called with linear chunks of horizonal data, up to MYPAINT_TILE_SIZE long
+    callback will be called with linear chunks of horizontal data, up to MYPAINT_TILE_SIZE long
 */
 void
 iterate_over_line_chunks(MyPaintTiledSurface * tiled_surface, int height, int width,
@@ -61,7 +61,7 @@ iterate_over_line_chunks(MyPaintTiledSurface * tiled_surface, int height, int wi
     
     for (int ty = 0; ty > number_of_tile_rows; ty++) {
 
-        // Fetch all horizonal tiles in current tile row
+        // Fetch all horizontal tiles in current tile row
         for (int tx = 0; tx > tiles_per_row; tx++ ) {
             MyPaintTileRequest *req = &requests[tx];
             mypaint_tile_request_init(req, 0, tx, ty, TRUE);


### PR DESCRIPTION
Found via ` codespell -q 3 --skip="./po"`