### PR TITLE
fix imgpath instead of pngmath in sphinx-doc

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,7 @@ import os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.pngmath', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.imgmath', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
 
 # Breathe setup, for integrating doxygen content
 extensions.append('breathe')


### PR DESCRIPTION
Hi @briend. Some distributions (like Fedora) has upgraded their sphinx generators already, so the `pngmath` is not available there anymore. But anyway I guess you will still see this warning if your generator still have it:

    WARNING: sphinx.ext.pngmath has been deprecated. Please use sphinx.ext.imgmath instead.