### PR TITLE
Fix brush settings/options not being translated

### DIFF
--- a/mypaint-brush-settings.c
+++ b/mypaint-brush-settings.c
@@ -21,8 +21,6 @@
 #include <string.h>
 #include <assert.h>
 
-#define GETTEXT_PACKAGE "libmypaint"
-
 #ifdef HAVE_GETTEXT
   #include <libintl.h>
   #define N_(String) (String)


### PR DESCRIPTION
Use correct text domain for the dgettext calls.
The ./configure -generated definition of GETTEXT_PACKAGE
(in config.h) was being overridden by the older definition.