### PR TITLE
Fix includes of local headers (angle brackets -> double quotes)

### DIFF
--- a/brushmodes.c
+++ b/brushmodes.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdint.h>
 #include <assert.h>

--- a/fifo.c
+++ b/fifo.c
@@ -15,7 +15,7 @@
  *
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 #include "fifo.h"

--- a/gegl/mypaint-gegl-surface.c
+++ b/gegl/mypaint-gegl-surface.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 #include <assert.h>

--- a/gegl/mypaint-gegl-surface.h
+++ b/gegl/mypaint-gegl-surface.h
@@ -21,9 +21,9 @@
 
 G_BEGIN_DECLS
 
-#include <mypaint-config.h>
-#include <glib/mypaint-gegl-glib.h>
-#include <mypaint-tiled-surface.h>
+#include "mypaint-config.h"
+#include "glib/mypaint-gegl-glib.h"
+#include "mypaint-tiled-surface.h"
 
 typedef struct MyPaintGeglTiledSurface MyPaintGeglTiledSurface;
 

--- a/glib/mypaint-brush.c
+++ b/glib/mypaint-brush.c
@@ -1,5 +1,5 @@
 
-#include <mypaint-config.h>
+#include "mypaint-config.h"
 
 #if MYPAINT_CONFIG_USE_GLIB
 

--- a/glib/mypaint-brush.h
+++ b/glib/mypaint-brush.h
@@ -1,7 +1,7 @@
 #ifndef MYPAINTBRUSHGLIB_H
 #define MYPAINTBRUSHGLIB_H
 
-#include <mypaint-config.h>
+#include "mypaint-config.h"
 
 #include <glib-object.h>
 

--- a/glib/mypaint-gegl-glib.c
+++ b/glib/mypaint-gegl-glib.c
@@ -1,5 +1,5 @@
-#include <config.h>
-#include <mypaint-config.h>
+#include "config.h"
+#include "mypaint-config.h"
 
 #if MYPAINT_CONFIG_USE_GLIB
 

--- a/glib/mypaint-gegl-glib.h
+++ b/glib/mypaint-gegl-glib.h
@@ -1,7 +1,7 @@
 #ifndef MYPAINTGEGLGLIB_H
 #define MYPAINTGEGLGLIB_H
 
-#include <mypaint-config.h>
+#include "mypaint-config.h"
 
 #include <glib-object.h>
 #define MYPAINT_GEGL_TYPE_TILED_SURFACE (mypaint_gegl_tiled_surface_get_type ())

--- a/helpers.c
+++ b/helpers.c
@@ -17,7 +17,7 @@
 #ifndef HELPERS_C
 #define HELPERS_C
 
-#include <config.h>
+#include "config.h"
 
 #include <assert.h>
 #include <stdint.h>

--- a/mypaint-brush-settings.c
+++ b/mypaint-brush-settings.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "mypaint-brush-settings.h"
 

--- a/mypaint-brush-settings.h
+++ b/mypaint-brush-settings.h
@@ -17,9 +17,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <mypaint-config.h>
-#include <mypaint-glib-compat.h>
-#include <mypaint-brush-settings-gen.h>
+#include "mypaint-config.h"
+#include "mypaint-glib-compat.h"
+#include "mypaint-brush-settings-gen.h"
 
 G_BEGIN_DECLS
 

--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -24,7 +24,7 @@
 
 #if MYPAINT_CONFIG_USE_GLIB
 #include <glib.h>
-#include <glib/mypaint-brush.h>
+#include "glib/mypaint-brush.h"
 #endif
 
 #include "mypaint-brush.h"

--- a/mypaint-brush.h
+++ b/mypaint-brush.h
@@ -18,9 +18,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <mypaint-config.h>
-#include <mypaint-surface.h>
-#include <mypaint-brush-settings.h>
+#include "mypaint-config.h"
+#include "mypaint-surface.h"
+#include "mypaint-brush-settings.h"
 
 G_BEGIN_DECLS
 

--- a/mypaint-fixed-tiled-surface.c
+++ b/mypaint-fixed-tiled-surface.c
@@ -4,13 +4,13 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <config.h>
+#include "config.h"
 
 #if MYPAINT_CONFIG_USE_GLIB
 #include <glib.h>
 #endif
 
-#include <mypaint-fixed-tiled-surface.h>
+#include "mypaint-fixed-tiled-surface.h"
 
 
 struct MyPaintFixedTiledSurface {

--- a/mypaint-fixed-tiled-surface.h
+++ b/mypaint-fixed-tiled-surface.h
@@ -1,9 +1,9 @@
 #ifndef MYPAINTFIXEDTILEDSURFACE_H
 #define MYPAINTFIXEDTILEDSURFACE_H
 
-#include <mypaint-config.h>
-#include <mypaint-glib-compat.h>
-#include <mypaint-tiled-surface.h>
+#include "mypaint-config.h"
+#include "mypaint-glib-compat.h"
+#include "mypaint-tiled-surface.h"
 
 G_BEGIN_DECLS
 

--- a/mypaint-glib-compat.h
+++ b/mypaint-glib-compat.h
@@ -1,7 +1,7 @@
 #ifndef MYPAINTGLIBCOMPAT_H
 #define MYPAINTGLIBCOMPAT_H
 
-#include <mypaint-config.h>
+#include "mypaint-config.h"
 
 #ifndef __G_LIB_H__
 

--- a/mypaint-mapping.c
+++ b/mypaint-mapping.c
@@ -17,7 +17,7 @@
 #ifndef MAPPING_C
 #define MAPPING_C
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 #include <assert.h>

--- a/mypaint-mapping.h
+++ b/mypaint-mapping.h
@@ -1,8 +1,8 @@
 #ifndef MAPPING_H
 #define MAPPING_H
 
-#include <mypaint-config.h>
-#include <mypaint-glib-compat.h>
+#include "mypaint-config.h"
+#include "mypaint-glib-compat.h"
 
 G_BEGIN_DECLS
 

--- a/mypaint-rectangle.c
+++ b/mypaint-rectangle.c
@@ -15,9 +15,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <config.h>
+#include "config.h"
 
-#include <mypaint-rectangle.h>
+#include "mypaint-rectangle.h"
 #include <stdlib.h>
 #include <string.h>
 

--- a/mypaint-rectangle.h
+++ b/mypaint-rectangle.h
@@ -18,8 +18,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <mypaint-config.h>
-#include <mypaint-glib-compat.h>
+#include "mypaint-config.h"
+#include "mypaint-glib-compat.h"
 
 G_BEGIN_DECLS
 

--- a/mypaint-surface.c
+++ b/mypaint-surface.c
@@ -15,7 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <assert.h>
 

--- a/mypaint-surface.h
+++ b/mypaint-surface.h
@@ -18,8 +18,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <mypaint-config.h>
-#include <mypaint-rectangle.h>
+#include "mypaint-config.h"
+#include "mypaint-rectangle.h"
 
 G_BEGIN_DECLS
 

--- a/mypaint-tiled-surface.c
+++ b/mypaint-tiled-surface.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <math.h>
 #include <stdio.h>

--- a/mypaint-tiled-surface.h
+++ b/mypaint-tiled-surface.h
@@ -2,8 +2,8 @@
 #define MYPAINTTILEDSURFACE_H
 
 #include <stdint.h>
-#include <mypaint-surface.h>
-#include <mypaint-config.h>
+#include "mypaint-surface.h"
+#include "mypaint-config.h"
 
 typedef enum {
     MYPAINT_SYMMETRY_TYPE_VERTICAL,

--- a/mypaint.c
+++ b/mypaint.c
@@ -1,6 +1,6 @@
 
-#include <config.h>
-#include <mypaint-config.h>
+#include "config.h"
+#include "mypaint-config.h"
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/operationqueue.c
+++ b/operationqueue.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 #include <assert.h>
@@ -22,7 +22,7 @@
 #if MYPAINT_CONFIG_USE_GLIB
 #include <glib.h>
 #else // not MYPAINT_CONFIG_USE_GLIB
-#include <mypaint-glib-compat.h>
+#include "mypaint-glib-compat.h"
 #endif
 
 #include "operationqueue.h"

--- a/rng-double.c
+++ b/rng-double.c
@@ -21,7 +21,7 @@
  * independent generator objects. All changes made to this file are considered
  * to be in the public domain. */
 
-#include <config.h>
+#include "config.h"
 
 #include "rng-double.h"
 

--- a/rng-double.h
+++ b/rng-double.h
@@ -6,7 +6,7 @@
 #if MYPAINT_CONFIG_USE_GLIB
 #include <glib.h>
 #else // not MYPAINT_CONFIG_USE_GLIB
-#include <mypaint-glib-compat.h>
+#include "mypaint-glib-compat.h"
 #endif
 
 

--- a/tests/mypaint-benchmark.c
+++ b/tests/mypaint-benchmark.c
@@ -19,7 +19,7 @@
 #if MYPAINT_CONFIG_USE_GLIB
 #include <glib.h>
 #else // not MYPAINT_CONFIG_USE_GLIB
-#include <mypaint-glib-compat.h>
+#include "mypaint-glib-compat.h"
 #endif
 
 #include <stdio.h>

--- a/tests/mypaint-test-surface.h
+++ b/tests/mypaint-test-surface.h
@@ -1,8 +1,8 @@
 #ifndef MYPAINTTESTSURFACE_H
 #define MYPAINTTESTSURFACE_H
 
-#include <mypaint-surface.h>
-#include <mypaint-glib-compat.h>
+#include "mypaint-surface.h"
+#include "mypaint-glib-compat.h"
 
 G_BEGIN_DECLS
 

--- a/tests/mypaint-utils-stroke-player.h
+++ b/tests/mypaint-utils-stroke-player.h
@@ -17,8 +17,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <mypaint-brush.h>
-#include <mypaint-surface.h>
+#include "mypaint-brush.h"
+#include "mypaint-surface.h"
 
 typedef struct MyPaintUtilsStrokePlayer MyPaintUtilsStrokePlayer;
 

--- a/tests/test-brush-load.c
+++ b/tests/test-brush-load.c
@@ -1,5 +1,5 @@
 
-#include <mypaint-brush.h>
+#include "mypaint-brush.h"
 
 #include "testutils.h"
 

--- a/tests/test-brush-persistence.c
+++ b/tests/test-brush-persistence.c
@@ -1,5 +1,5 @@
 
-#include <mypaint-brush.h>
+#include "mypaint-brush.h"
 
 #include "testutils.h"
 

--- a/tests/test-fixed-tiled-surface.c
+++ b/tests/test-fixed-tiled-surface.c
@@ -1,7 +1,7 @@
 
 #include <stddef.h>
 
-#include <mypaint-fixed-tiled-surface.h>
+#include "mypaint-fixed-tiled-surface.h"
 #include "mypaint-test-surface.h"
 
 MyPaintSurface *

--- a/tilemap.c
+++ b/tilemap.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 #include <assert.h>

--- a/tilemap.h
+++ b/tilemap.h
@@ -20,7 +20,7 @@
 #if MYPAINT_CONFIG_USE_GLIB
 #include <glib.h>
 #else // not MYPAINT_CONFIG_USE_GLIB
-#include <mypaint-glib-compat.h>
+#include "mypaint-glib-compat.h"
 #endif
 
 G_BEGIN_DECLS

--- a/utils.c
+++ b/utils.c
@@ -1,6 +1,6 @@
 /* Utilities which might become part of public API in the future  */
 
-#include <config.h>
+#include "config.h"
 
 #include "mypaint-config.h"
 #include "mypaint-tiled-surface.h"


### PR DESCRIPTION
I'm guessing that the use of angle-brackets for these includes is a remnant of times long past (from before the lib split). If there is an actual reason for using brackets in these includes, do tell. Otherwise I'll merge this in a day or two.