### PR TITLE
Adjustable symmetry angle

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,7 @@ nobase_libmypaint_public_HEADERS = \
 	mypaint-glib-compat.h			\
 	mypaint-mapping.h				\
 	mypaint-matrix.h	\
+	mypaint-symmetry.h	\
 	$(MyPaint_introspectable_headers)
 
 LIBMYPAINT_SOURCES = \
@@ -118,6 +119,7 @@ LIBMYPAINT_SOURCES = \
 	mypaint-brush-settings.c		\
 	mypaint-fixed-tiled-surface.c	\
 	mypaint-matrix.c	\
+	mypaint-symmetry.c	\
 	mypaint-rectangle.c				\
 	mypaint-surface.c				\
 	mypaint-tiled-surface.c			\

--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,7 @@ nobase_libmypaint_public_HEADERS = \
 	mypaint-config.h				\
 	mypaint-glib-compat.h			\
 	mypaint-mapping.h				\
+	mypaint-matrix.h	\
 	$(MyPaint_introspectable_headers)
 
 LIBMYPAINT_SOURCES = \
@@ -116,6 +117,7 @@ LIBMYPAINT_SOURCES = \
 	mypaint-brush.c					\
 	mypaint-brush-settings.c		\
 	mypaint-fixed-tiled-surface.c	\
+	mypaint-matrix.c	\
 	mypaint-rectangle.c				\
 	mypaint-surface.c				\
 	mypaint-tiled-surface.c			\

--- a/helpers.h
+++ b/helpers.h
@@ -14,6 +14,10 @@
 #define MIN3(a, b, c) ((a)<(b)?MIN((a),(c)):MIN((b),(c)))
 #define WGM_EPSILON 0.001
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 void
 hsl_to_rgb_float (float *h_, float *s_, float *l_);
 void

--- a/mypaint-brush.c
+++ b/mypaint-brush.c
@@ -44,10 +44,6 @@
 #endif
 #endif
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 // Conversion from degree to radians
 #define RADIANS(x) ((x) * M_PI / 180.0)
 

--- a/mypaint-matrix.c
+++ b/mypaint-matrix.c
@@ -1,0 +1,92 @@
+/* libmypaint - The MyPaint Brush Library
+ * Copyright (C) 2019 The MyPaint Team
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "mypaint-matrix.h"
+#include <math.h>
+
+MyPaintTransform
+mypaint_matrix_multiply(const MyPaintTransform m1, const MyPaintTransform m2)
+{
+    MyPaintTransform result;
+    for (int row = 0; row < 3; ++row) {
+      for (int col = 0; col < 3; ++col) {
+	  result.rows[row][col] =
+	    m1.rows[0][col] * m2.rows[row][0] +
+	    m1.rows[1][col] * m2.rows[row][1] +
+	    m1.rows[2][col] * m2.rows[row][2];
+        }
+    }
+    return result;
+}
+
+MyPaintTransform
+mypaint_transform_unit()
+{
+    MyPaintTransform m = {{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}};
+    return m;
+}
+
+MyPaintTransform
+mypaint_transform_rotate_cw(const MyPaintTransform transform, const float angle_radians)
+{
+    const float a = angle_radians;
+    MyPaintTransform factor = {{{cos(a), sin(a), 0}, {-sin(a), cos(a), 0}, {0, 0, 1}}};
+    return mypaint_matrix_multiply(transform, factor);
+}
+
+MyPaintTransform
+mypaint_transform_rotate_ccw(const MyPaintTransform transform, const float angle_radians)
+{
+    const float a = angle_radians;
+    MyPaintTransform factor = {{
+        {cos(a), -sin(a), 0},
+        {sin(a), cos(a), 0},
+        {0, 0, 1},
+    }};
+    return mypaint_matrix_multiply(transform, factor);
+}
+
+MyPaintTransform
+mypaint_transform_reflect(const MyPaintTransform transform, const float angle_radians)
+{
+    float x = cos(angle_radians);
+    float y = sin(angle_radians);
+    MyPaintTransform factor = {{
+        {x * x - y * y, 2.0 * x * y, 0},
+        {2.0 * x * y, y * y - x * x, 0},
+        {0, 0, 1},
+    }};
+    return mypaint_matrix_multiply(transform, factor);
+}
+
+
+MyPaintTransform
+mypaint_transform_translate(const MyPaintTransform transform, const float x, const float y)
+{
+    MyPaintTransform factor = {{
+	{1, 0, x},
+	{0, 1, y},
+	{0, 0, 1},
+      }};
+    return mypaint_matrix_multiply(transform, factor);
+}
+
+void
+mypaint_transform_point(const MyPaintTransform* const t, float x, float y, float* xout, float* yout)
+{
+    *xout = t->rows[0][0] * x + t->rows[0][1] * y + t->rows[0][2];
+    *yout = t->rows[1][0] * x + t->rows[1][1] * y + t->rows[1][2];
+}

--- a/mypaint-matrix.h
+++ b/mypaint-matrix.h
@@ -1,0 +1,32 @@
+#ifndef MYPAINTMATRIX_H
+#define MYPAINTMATRIX_H
+
+/* libmypaint - The MyPaint Brush Library
+ * Copyright (C) 2019 The MyPaint Team
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+typedef struct {
+  float rows[3][3];
+} MyPaintTransform;
+
+MyPaintTransform mypaint_transform_unit();
+MyPaintTransform mypaint_transform_rotate_cw(const MyPaintTransform transform, const float angle_radians);
+MyPaintTransform mypaint_transform_rotate_ccw(const MyPaintTransform transform, const float angle_radians);
+MyPaintTransform mypaint_transform_reflect(const MyPaintTransform transform, const float angle_radians);
+MyPaintTransform mypaint_transform_translate(const MyPaintTransform transform, const float x, const float y);
+
+void mypaint_transform_point(const MyPaintTransform* const t, float x, float y, float* x_out, float* y_out);
+
+#endif

--- a/mypaint-symmetry.c
+++ b/mypaint-symmetry.c
@@ -1,0 +1,161 @@
+#include "mypaint-symmetry.h"
+#include "helpers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DEFAULT_NUM_MATRICES 16
+
+void
+allocation_failure_warning(int num)
+{
+    fprintf(stderr, "Critical: failed to allocate memory for %d transformation matrices!\n", num);
+}
+
+gboolean
+allocate_symmetry_matrices(MyPaintSymmetryData* data, int num_matrices)
+{
+    int bytes = num_matrices * sizeof(MyPaintTransform);
+    void* allocated = realloc(data->symmetry_matrices, bytes);
+    if (!allocated) {
+        allocation_failure_warning(num_matrices);
+        data->num_symmetry_matrices = 0;
+        return FALSE;
+    } else {
+        data->symmetry_matrices = allocated;
+        data->num_symmetry_matrices = num_matrices;
+        return TRUE;
+    }
+}
+
+gboolean
+symmetry_states_equal(const MyPaintSymmetryState* const s1, const MyPaintSymmetryState* const s2)
+{
+    return s1->type == s2->type && s1->center_x == s2->center_x && s1->center_y == s2->center_y &&
+           s1->angle == s2->angle && s1->num_lines == s2->num_lines;
+}
+
+int
+num_matrices_required(const MyPaintSymmetryState* state)
+{
+    switch (state->type) {
+    case MYPAINT_SYMMETRY_TYPE_VERTICAL:
+    case MYPAINT_SYMMETRY_TYPE_HORIZONTAL:
+        return 1;
+    case MYPAINT_SYMMETRY_TYPE_VERTHORZ:
+        return 3;
+    case MYPAINT_SYMMETRY_TYPE_ROTATIONAL:
+        return state->num_lines - 1;
+    case MYPAINT_SYMMETRY_TYPE_SNOWFLAKE:
+        return 2 * state->num_lines - 1;
+    default:
+        return 0;
+    }
+}
+
+/* Public functions */
+
+MyPaintSymmetryState
+symmetry_state_default()
+{
+    MyPaintSymmetryState base = {
+        .type = MYPAINT_SYMMETRY_TYPE_VERTICAL, .center_x = 0.0, .center_y = 0.0, .angle = 0.0, .num_lines = 2};
+    return base;
+}
+
+/* If the symmetry state has changed since last, recalculate matrices */
+void
+mypaint_update_symmetry_state(MyPaintSymmetryData* const self)
+{
+    if (!self->pending_changes || symmetry_states_equal(&self->state_current, &self->state_pending)) return;
+    // Need to recalculate matrices
+    // Check if we need to allocate more space
+    const int required = num_matrices_required(&self->state_pending);
+    if (self->num_symmetry_matrices < required) {
+        // Try to allocate space for matrices, skip recalculations if it fails
+        if (!allocate_symmetry_matrices(self, required)) return;
+    }
+    const MyPaintSymmetryState symm = self->state_pending;
+    self->state_current = symm;
+    float cx = symm.center_x;
+    float cy = symm.center_y;
+    // Convert angle to radians
+    float angle = symm.angle * (M_PI / 180.0);
+    float rot_angle = (2.0 * M_PI) / symm.num_lines;
+    MyPaintTransform* matrices = self->symmetry_matrices;
+    const MyPaintTransform m = mypaint_transform_translate(mypaint_transform_unit(), -cx, -cy);
+    switch (symm.type) {
+    case MYPAINT_SYMMETRY_TYPE_HORIZONTAL:
+    case MYPAINT_SYMMETRY_TYPE_VERTICAL: {
+        if (symm.type == MYPAINT_SYMMETRY_TYPE_VERTICAL) {
+            angle += M_PI / 2.0;
+        }
+        matrices[0] = mypaint_transform_reflect(m, -angle);
+    } break;
+    case MYPAINT_SYMMETRY_TYPE_VERTHORZ: {
+        float v_angle = angle + M_PI / 2.0;
+        matrices[0] = mypaint_transform_reflect(m, -angle);
+        matrices[1] = mypaint_transform_reflect(matrices[0], -v_angle);
+        matrices[2] = mypaint_transform_reflect(matrices[1], -angle);
+    } break;
+    case MYPAINT_SYMMETRY_TYPE_SNOWFLAKE: {
+        int base_idx = symm.num_lines - 1;
+        for (int i = 0; i < symm.num_lines; ++i) {
+            matrices[base_idx + i] =
+                mypaint_transform_reflect(mypaint_transform_rotate_cw(m, rot_angle * i), -i * rot_angle - angle);
+        }
+    }
+    case MYPAINT_SYMMETRY_TYPE_ROTATIONAL: {
+        for (int i = 1; i < symm.num_lines; ++i) {
+            matrices[i - 1] = mypaint_transform_rotate_cw(m, rot_angle * i);
+        }
+    } break;
+    default:
+        fprintf(stderr, "Warning: Unhandled symmetry type: %d\n", symm.type);
+        return;
+    }
+    for (int i = 0; i < required; ++i) {
+        matrices[i] = mypaint_transform_translate(matrices[i], cx, cy);
+    }
+    self->pending_changes = FALSE;
+}
+
+MyPaintSymmetryData
+mypaint_default_symmetry_data()
+{
+    MyPaintSymmetryData symm_data = {
+        .state_current = {.type = -1},
+        .state_pending = symmetry_state_default(),
+        .pending_changes = TRUE,
+        .active = FALSE,
+        .num_symmetry_matrices = DEFAULT_NUM_MATRICES,
+        .symmetry_matrices = NULL,
+    };
+    if (allocate_symmetry_matrices(&symm_data, DEFAULT_NUM_MATRICES)) {
+        mypaint_update_symmetry_state(&symm_data);
+    }
+    return symm_data;
+}
+
+void
+mypaint_symmetry_data_destroy(MyPaintSymmetryData* data)
+{
+    if (data->symmetry_matrices != NULL) {
+        free(data->symmetry_matrices);
+    }
+}
+
+void
+mypaint_symmetry_set_pending(
+    MyPaintSymmetryData* data, gboolean active, float center_x, float center_y, float symmetry_angle,
+    MyPaintSymmetryType symmetry_type, int rot_symmetry_lines)
+{
+    data->active = active;
+    data->state_pending.center_x = center_x;
+    data->state_pending.center_y = center_y;
+    data->state_pending.type = symmetry_type;
+    data->state_pending.num_lines = MAX(2, rot_symmetry_lines);
+    data->state_pending.angle = symmetry_angle;
+
+    data->pending_changes = TRUE;
+}

--- a/mypaint-symmetry.h
+++ b/mypaint-symmetry.h
@@ -1,0 +1,84 @@
+#ifndef MYPAINTSYMMETRY_H
+#define MYPAINTSYMMETRY_H
+/* libmypaint - The MyPaint Brush Library
+ * Copyright (C) 2017-2019 The MyPaint Team
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "mypaint-matrix.h"
+#include "mypaint-glib-compat.h"
+
+/**
+  * MyPaintSymmetryType: Enumeration of different kinds of symmetry
+  *
+  * Prefix = 'MYPAINT_SYMMETRY_TYPE_'
+  * VERTICAL: reflection across the y-axis
+  * HORIZONTAL: reflection across the x-axis
+  * VERTHORZ: reflection across x-axis and y-axis, special case of SNOWFLAKE
+  * ROTATIONAL: rotational symmetry by N symmetry lines around a point
+  * SNOWFLAKE: rotational symmetry w. reflection across the N symmetry lines
+  */
+typedef enum {
+    MYPAINT_SYMMETRY_TYPE_VERTICAL,
+    MYPAINT_SYMMETRY_TYPE_HORIZONTAL,
+    MYPAINT_SYMMETRY_TYPE_VERTHORZ,
+    MYPAINT_SYMMETRY_TYPE_ROTATIONAL,
+    MYPAINT_SYMMETRY_TYPE_SNOWFLAKE,
+    MYPAINT_SYMMETRY_TYPES_COUNT
+} MyPaintSymmetryType;
+
+
+/**
+  * MyPaintSymmetryState: Contains the basis for symmetry calculations
+  *
+  * This is used to calculate the matrices that are
+  * used for the actual symmetry calculations, and to
+  * determine whether the matrices need to be recalculated.
+  */
+typedef struct {
+  MyPaintSymmetryType type;
+  float center_x;
+  float center_y;
+  float angle;
+  float num_lines;
+} MyPaintSymmetryState;
+
+/**
+  * MyPaintSymmetryData: Contains data used for symmetry calculations
+  *
+  * Instances contain a current and pending symmetry basis, and the
+  * matrices used for the actual symmetry transforms. When the pending
+  * state is modified, the "pending_changes" flag should be set.
+  * Matrix recalculation should not be performed during draw operations.
+  */
+typedef struct {
+  MyPaintSymmetryState state_current;
+  MyPaintSymmetryState state_pending;
+  gboolean pending_changes;
+  gboolean active;
+  int num_symmetry_matrices;
+  MyPaintTransform *symmetry_matrices;
+} MyPaintSymmetryData;
+
+void mypaint_update_symmetry_state(MyPaintSymmetryData * const symmetry_data);
+
+MyPaintSymmetryData mypaint_default_symmetry_data();
+
+void mypaint_symmetry_data_destroy(MyPaintSymmetryData *);
+
+void mypaint_symmetry_set_pending(
+    MyPaintSymmetryData* data, gboolean active, float center_x, float center_y,
+    float symmetry_angle, MyPaintSymmetryType symmetry_type, int rot_symmetry_lines);
+
+#endif

--- a/mypaint-tiled-surface.h
+++ b/mypaint-tiled-surface.h
@@ -3,18 +3,10 @@
 
 #include <stdint.h>
 #include "mypaint-surface.h"
+#include "mypaint-symmetry.h"
 #include "mypaint-config.h"
 
 #define NUM_BBOXES_DEFAULT 32
-
-typedef enum {
-    MYPAINT_SYMMETRY_TYPE_VERTICAL,
-    MYPAINT_SYMMETRY_TYPE_HORIZONTAL,
-    MYPAINT_SYMMETRY_TYPE_VERTHORZ,
-    MYPAINT_SYMMETRY_TYPE_ROTATIONAL,
-    MYPAINT_SYMMETRY_TYPE_SNOWFLAKE,
-    MYPAINT_SYMMETRY_TYPES_COUNT
-} MyPaintSymmetryType;
 
 G_BEGIN_DECLS
 
@@ -38,6 +30,7 @@ typedef void (*MyPaintTileRequestStartFunction) (MyPaintTiledSurface *self, MyPa
 typedef void (*MyPaintTileRequestEndFunction) (MyPaintTiledSurface *self, MyPaintTileRequest *request);
 typedef void (*MyPaintTiledSurfaceAreaChanged) (MyPaintTiledSurface *self, int bb_x, int bb_y, int bb_w, int bb_h);
 
+
 /**
   * MyPaintTiledSurface:
   *
@@ -50,11 +43,7 @@ struct MyPaintTiledSurface {
     /* private: */
     MyPaintTileRequestStartFunction tile_request_start;
     MyPaintTileRequestEndFunction tile_request_end;
-    gboolean surface_do_symmetry;
-    MyPaintSymmetryType symmetry_type;
-    float surface_center_x;
-    float surface_center_y;
-    int rot_symmetry_lines;
+    MyPaintSymmetryData symmetry_data;
     struct OperationQueue *operation_queue;
     int num_bboxes;
     int num_bboxes_dirtied;
@@ -75,6 +64,7 @@ mypaint_tiled_surface_destroy(MyPaintTiledSurface *self);
 void
 mypaint_tiled_surface_set_symmetry_state(MyPaintTiledSurface *self, gboolean active,
                                          float center_x, float center_y,
+                                         float symmetry_angle,
                                          MyPaintSymmetryType symmetry_type,
                                          int rot_symmetry_lines);
 float


### PR DESCRIPTION
Adds a matrix type, with some basic transforms, refactors the symmetry code to make use of precalculated transformation matrices and splits it out into a separate source/header file.

The ability to adjust the angle of the symmetry lines is added, allowing for much more flexible use.

This breaks the API in two ways: adding the angle parameter to `set_symmetry_state` and changing the layout/contents of the `MyPaintTiledSurface` struct. To my knowledge, no other program than MyPaint makes use of _that part_ of the API, so it shouldn't be an issue.