### PR TITLE
Fix Name and Requires in libmypaint-gegl.pc.

### DIFF
--- a/gegl/libmypaint-gegl.pc.in
+++ b/gegl/libmypaint-gegl.pc.in
@@ -3,9 +3,9 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: libmypaint-gegl
+Name: libmypaint-gegl-@LIBMYPAINT_API_PLATFORM_VERSION@
 Description: MyPaint brush engine library, with GEGL integration.
 Version: @LIBMYPAINT_VERSION@
-Requires: gegl-@GEGL_VERSION@ libmypaint
+Requires: gegl-@GEGL_VERSION@ libmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@
 Cflags: -I${includedir}/libmypaint-gegl
 Libs: -L${libdir} -lmypaint-gegl

--- a/gegl/libmypaint-gegl.pc.in
+++ b/gegl/libmypaint-gegl.pc.in
@@ -3,9 +3,9 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: libmypaint
+Name: libmypaint-gegl
 Description: MyPaint brush engine library, with GEGL integration.
 Version: @LIBMYPAINT_VERSION@
-Requires: gegl-0.3 libmypaint-@LIBMYPAINT_API_PLATFORM_VERSION@
+Requires: gegl-@GEGL_VERSION@ libmypaint
 Cflags: -I${includedir}/libmypaint-gegl
 Libs: -L${libdir} -lmypaint-gegl


### PR DESCRIPTION
* Correct version of gegl in Requires.
* libmypaint-1.5.pc doesn't exist, Requires: libmypaint instead, without
  the versioning.
* Change Name to libmypaint-gegl to distinguish from libmypaint.pc which
  already uses Name: libmypaint.