### PR TITLE
Add arch ppc64le and Dist Xenial to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: c
 
+arch:
+ - amd64
+ - ppc64le
+
 compiler:
   - gcc
 
 sudo: required
 
-dist: trusty
+dist: Xenial
 
 addons:
   apt:


### PR DESCRIPTION
Hi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch and updated Dist to Xenial

The Travis ci build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/libmypaint
Please have a look.

Thank you