### PR TITLE
Fix changing alpha with alpha lock

### DIFF
--- a/brushmodes.c
+++ b/brushmodes.c
@@ -477,7 +477,6 @@ void draw_dab_pixels_BlendMode_LockAlpha_Paint (uint16_t * mask,
       // convert back to RGB
       float rgb_result[3] = {0};
       spectral_to_rgb(spectral_result, rgb_result);
-      rgba[3] = opa_a + opa_b * rgba[3] / (1<<15);
 
       for (int i=0; i<3; i++) {
         rgba[i] =(rgb_result[i] * rgba[3]) + 0.5;


### PR DESCRIPTION
Deleted line should not change value of alpha.
This line, with lossless precision, can be written as:
`alpha = alpha*mask*opacity + alpha*(1 - mask*opacity)`
and simplified to:
`alpha = alpha * 1`
but use of fixed point math introduces loss of precision.

Problem can be reproduced in MyPaint:
1. paint some shape with less than 100% opacity
2. enable alpha lock: Menu -> Brush -> Paint mode -> alpha lock
3. paint over shape witch alpha lock
4. after some time opacity will start to decrease, it is more visible on layers with pigment mode