### PR TITLE
Make autogen.sh aware of automake-1.17

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -9,10 +9,10 @@
 # tools and you shouldn't use this script.  Just call ./configure
 # directly.
 
-ACLOCAL=${ACLOCAL-aclocal-1.16}
+ACLOCAL=${ACLOCAL-aclocal-1.17}
 AUTOCONF=${AUTOCONF-autoconf}
 AUTOHEADER=${AUTOHEADER-autoheader}
-AUTOMAKE=${AUTOMAKE-automake-1.16}
+AUTOMAKE=${AUTOMAKE-automake-1.17}
 LIBTOOLIZE=${LIBTOOLIZE-libtoolize}
 PYTHON=${PYTHON-python}
 
@@ -128,6 +128,9 @@ printf "checking for automake >= $AUTOMAKE_REQUIRED_VERSION ... "
 if ($AUTOMAKE --version) < /dev/null > /dev/null 2>&1; then
    AUTOMAKE=$AUTOMAKE
    ACLOCAL=$ACLOCAL
+elif (automake-1.17 --version) < /dev/null > /dev/null 2>&1; then
+   AUTOMAKE=automake-1.17
+   ACLOCAL=aclocal-1.17
 elif (automake-1.16 --version) < /dev/null > /dev/null 2>&1; then
    AUTOMAKE=automake-1.16
    ACLOCAL=aclocal-1.16


### PR DESCRIPTION
autogen.sh manually checks acceptable versions of automake. Previously it wasn't aware of automake v1.17, but now it is.

Fixes #199