### PR TITLE
Finished Fifo API to track and retrieve item count from fifo queue

### DIFF
--- a/fifo.c
+++ b/fifo.c
@@ -30,7 +30,7 @@ struct fifo
 {
     struct fifo_item *first;  /* first pushed item */
     struct fifo_item *last;   /* last pushed item */
-    int item_count;
+    unsigned int item_count;
 };
 
 /*
@@ -79,6 +79,8 @@ void fifo_push(struct fifo* queue, void* data)
     else
         queue->last->next = item;
     queue->last = item;
+    
+    queue->item_count++;
 }
 
 /*
@@ -111,4 +113,8 @@ void* fifo_peek_first(struct fifo *queue) {
 
 void* fifo_peek_last(struct fifo *queue) {
     return (!queue->last) ? NULL : queue->last->payload;
+}
+
+unsigned int fifo_item_count(struct fifo *queue) {
+    return (!queue->first) ? 0 : queue->item_count;
 }

--- a/fifo.h
+++ b/fifo.h
@@ -13,4 +13,5 @@ void* fifo_pop(Fifo* self);
 void* fifo_peek_first(Fifo *queue);
 void* fifo_peek_last(Fifo *queue);
 
+unsigned int fifo_item_count(struct fifo *queue);
 #endif // FIFO_H

--- a/operationqueue.c
+++ b/operationqueue.c
@@ -253,3 +253,13 @@ operation_queue_peek_last(OperationQueue *self, TileIndex index) {
     Fifo *op_queue = (Fifo *)*tile_map_get(self->tile_map, index);
     return (!op_queue) ? NULL : (OperationDataDrawDab *)fifo_peek_last(op_queue);
 }
+
+unsigned int operation_queue_item_count(OperationQueue *self, TileIndex index) {
+    if (!tile_map_contains(self->tile_map, index)) {
+        return 0;
+    }
+
+    Fifo *op_queue = (Fifo *)*tile_map_get(self->tile_map, index);
+    return (!op_queue) ? 0 : fifo_item_count(op_queue);
+
+}

--- a/operationqueue.h
+++ b/operationqueue.h
@@ -39,4 +39,5 @@ OperationDataDrawDab *operation_queue_pop(OperationQueue *self, TileIndex index)
 OperationDataDrawDab *operation_queue_peek_first(OperationQueue *self, TileIndex index);
 OperationDataDrawDab *operation_queue_peek_last(OperationQueue *self, TileIndex index);
 
+unsigned int operation_queue_item_count(OperationQueue *self, TileIndex index);
 #endif // OPERATIONQUEUE_H


### PR DESCRIPTION
Hello,

Going through the codebase I noticed that though _fifo_pop_ decremented item_count when popping an item, _fifo_push_  did not increment the item_count for every item stored in the queue.  I added this and provided an interface to retrieve the item count from the queue.

This is useful for analytics and benchmarking.

Thank you,

Arcmantis