### PR TITLE
Arcmantis/fix autotools flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,13 +130,13 @@ AC_ARG_ENABLE(debug,
 
 if eval "test x$enable_debug = xyes"; then
   AC_MSG_RESULT([yes])
-  CPPDEFINES='HEAVY_DEBUG $CPPDEFINES'
-  CCFLAGS='-O0 $CCFLAGS'
-  LINKFLAGS='-O0 $LINKFLAGS'
+  CPPFLAGS="HEAVY_DEBUG $CPPFLAGS"
+  CFLAGS="-O0 $CFLAGS"
+  LDFLAGS="-O0 $LDFLAGS"
 else
   AC_MSG_RESULT([no])
-  CCFLAGS='-O3 $CCFLAGS'
-  LINKFLAGS='-O3 $LINKFLAGS'
+  CFLAGS="-O3 $CFLAGS"
+  LDFLAGS="-O3 $LDFLAGS"
 fi
 
 ## Profiling ##
@@ -148,7 +148,7 @@ AC_ARG_ENABLE(profiling,
 
 if eval "test x$enable_profiling = xyes"; then
   AC_MSG_RESULT([yes])
-  CCFLAGS='-pg $CCFLAGS'
+  CFLAGS="-pg $CFLAGS"
 else
   AC_MSG_RESULT([no])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,7 @@ AC_ARG_ENABLE(debug,
 
 if eval "test x$enable_debug = xyes"; then
   AC_MSG_RESULT([yes])
-  CPPFLAGS="HEAVY_DEBUG $CPPFLAGS"
+  CPPFLAGS="-DHEAVY_DEBUG $CPPFLAGS"
   CFLAGS="-O0 $CFLAGS"
   LDFLAGS="-O0 $LDFLAGS"
 else

--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,7 @@ AC_ARG_ENABLE(profiling,
 if eval "test x$enable_profiling = xyes"; then
   AC_MSG_RESULT([yes])
   CFLAGS="-pg $CFLAGS"
+  LDFLAGS="-pg $LDFLAGS"
 else
   AC_MSG_RESULT([no])
 fi


### PR DESCRIPTION
I was unable to build the project with profiling enabled because the -pg compiler flag was not being passed to the compiler. After some investigation I found that configure.ac was assigning the flags to some 'dead' variables and not the correct autotools standards. I made the necessary corrections, as well as passing -pg to the linker flags for correct profiling. 

I also found that the HEAVY_DEBUG macro was not being properly defined and fixed that.

Thank you :)



